### PR TITLE
Implemented static layer bug fix

### DIFF
--- a/costmap_2d/plugins/static_layer.cpp
+++ b/costmap_2d/plugins/static_layer.cpp
@@ -233,11 +233,6 @@ void StaticLayer::incomingUpdate(const map_msgs::OccupancyGridUpdateConstPtr& up
       costmap_[index] = interpretValue(update->data[di++]);
     }
   }
-  x_ = update->x;
-  y_ = update->y;
-  width_ = update->width;
-  height_ = update->height;
-  has_updated_data_ = true;
 }
 
 void StaticLayer::activate()


### PR DESCRIPTION
- bug caused costmap dimensions to shrink after calling 'clear_costmaps'
  service while 'subscribe_to_updates' parameter was true.