### PR TITLE
move_base: add planner_retry_frequency

### DIFF
--- a/move_base/cfg/MoveBase.cfg
+++ b/move_base/cfg/MoveBase.cfg
@@ -12,6 +12,7 @@ gen.add("base_local_planner", str_t, 0, "The name of the plugin for the local pl
 #gen.add("recovery_behaviors", str_t, 0, "A list of recovery behavior plugins to use with move_base.", "[{name: conservative_reset, type: clear_costmap_recovery/ClearCostmapRecovery}, {name: rotate_recovery, type: rotate_recovery/RotateRecovery}, {name: aggressive_reset, type: clear_costmap_recovery/ClearCostmapRecovery}]")
 
 gen.add("planner_frequency", double_t, 0, "The rate in Hz at which to run the planning loop.", 0, 0, 100)
+gen.add("planner_retry_frequency", double_t, 0, "The rate in Hz at which to retry the planning loop on failure.", 10, 0, 1000)
 gen.add("controller_frequency", double_t, 0, "The rate in Hz at which to run the control loop and send velocity commands to the base.", 20, 0, 100)
 gen.add("planner_patience", double_t, 0, "How long the planner will wait in seconds in an attempt to find a valid plan before space-clearing operations are performed.", 5.0, 0, 100)
 gen.add("controller_patience", double_t, 0, "How long the controller will wait in seconds without receiving a valid control before space-clearing operations are performed.", 5.0, 0, 100)

--- a/move_base/include/move_base/move_base.h
+++ b/move_base/include/move_base/move_base.h
@@ -196,6 +196,7 @@ namespace move_base {
 
       tf::Stamped<tf::Pose> global_pose_;
       double planner_frequency_, controller_frequency_, inscribed_radius_, circumscribed_radius_;
+      double planner_retry_frequency_;
       double planner_patience_, controller_patience_;
       double conservative_reset_dist_, clearing_radius_;
       ros::Publisher current_goal_pub_, vel_pub_, action_goal_pub_;

--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -73,6 +73,7 @@ namespace move_base {
     private_nh.param("global_costmap/robot_base_frame", robot_base_frame_, std::string("base_link"));
     private_nh.param("global_costmap/global_frame", global_frame_, std::string("/map"));
     private_nh.param("planner_frequency", planner_frequency_, 0.0);
+    private_nh.param("planner_retry_frequency", planner_retry_frequency_, 10.0);
     private_nh.param("controller_frequency", controller_frequency_, 20.0);
     private_nh.param("planner_patience", planner_patience_, 5.0);
     private_nh.param("controller_patience", controller_patience_, 15.0);
@@ -205,6 +206,7 @@ namespace move_base {
       c_freq_change_ = true;
     }
 
+    planner_retry_frequency_ = config.planner_retry_frequency;
     planner_patience_ = config.planner_patience;
     controller_patience_ = config.controller_patience;
     conservative_reset_dist_ = config.conservative_reset_dist;
@@ -613,8 +615,14 @@ namespace move_base {
       lock.lock();
 
       //setup sleep interface if needed
-      if(planner_frequency_ > 0){
-        ros::Duration sleep_time = (start_time + ros::Duration(1.0/planner_frequency_)) - ros::Time::now();
+      {
+        ros::Duration sleep_time = ros::Duration(0.0);
+        if(planner_frequency_ > 0){
+          sleep_time = (start_time + ros::Duration(1.0/planner_frequency_)) - ros::Time::now();
+        }
+        else if(planner_retry_frequency_ > 0 && runPlanner_){
+          sleep_time = (start_time + ros::Duration(1.0/planner_retry_frequency_)) - ros::Time::now();
+        }
         if (sleep_time > ros::Duration(0.0)){
           wait_for_wake = true;
           timer = n.createTimer(sleep_time, &MoveBase::wakePlanner, this);


### PR DESCRIPTION
Add planner_retry_frequency limit how often we retry to make a plan.
This keeps move_base from spamming and spinning if a condition will
continue to keep us from making a plan (such as if the TF tree from map
to base_link is currently broken). Default the planner_retry_frequency
to 10 Hz, and allow a range of 0-1000Hz.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/navigation/2)
<!-- Reviewable:end -->
