### PR TITLE
add parameter to reverse tf direction

### DIFF
--- a/amcl/cfg/AMCL.cfg
+++ b/amcl/cfg/AMCL.cfg
@@ -28,6 +28,7 @@ gen.add("beam_skip_distance", double_t, 0, "Distance from a valid map point befo
 gen.add("beam_skip_threshold", double_t, 0, "Ratio of samples for which the scans are valid to consider as valid scan", 0, 1, 0.3)
 
 gen.add("tf_broadcast", bool_t, 0, "When true (the default), publish results via TF.  When false, do not.", True)
+gen.add("tf_reverse", bool_t, 0, "When set to true, reverse published TF.", False)
 gen.add("gui_publish_rate", double_t, 0, "Maximum rate (Hz) at which scans and paths are published for visualization, -1.0 to disable.", -1, -1, 100)
 gen.add("save_pose_rate", double_t, 0, "Maximum rate (Hz) at which to store the last estimated pose and covariance to the parameter server, in the variables ~initial_pose_* and ~initial_cov_*. This saved pose will be used on subsequent runs to initialize the filter. -1.0 to disable.", .5, 0, 10)
 


### PR DESCRIPTION
When evaluating multiple localizers, it is useful to run them side-by-side.
This is generally not possible unless the published TF can be reversed, since
a child node in the TF tree can not have multiple parents.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/navigation/4)
<!-- Reviewable:end -->
