### PR TITLE
fix race condition in static_layer costmap plugin

### DIFF
--- a/costmap_2d/plugins/static_layer.cpp
+++ b/costmap_2d/plugins/static_layer.cpp
@@ -85,10 +85,10 @@ void StaticLayer::onInitialize()
   if (!first_map_only_ || map_sub_.getTopic() != ros::names::resolve(map_topic))
   {
     // we'll subscribe to the latched topic that the map server uses
-    ROS_INFO("Requesting the map...");
-    map_sub_ = g_nh.subscribe(map_topic, 1, &StaticLayer::incomingMap, this);
     map_received_ = false;
     has_updated_data_ = false;
+    ROS_INFO("Requesting the map...");
+    map_sub_ = g_nh.subscribe(map_topic, 1, &StaticLayer::incomingMap, this);
 
     ros::Rate r(10);
     while (!map_received_ && g_nh.ok())


### PR DESCRIPTION
The static_layer waits for a map when calling onInitialize.
However, it sets the boolean to false after subscribing to the topic.
It is possible for the callback to be called prior to the boolean
being set, which prevents onInitialize from finishing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/navigation/5)
<!-- Reviewable:end -->
