### PR TITLE
Costmap 3D

### DIFF
--- a/base_local_planner/CMakeLists.txt
+++ b/base_local_planner/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(catkin REQUIRED
             pcl_conversions
             rostest
             costmap_2d
+            costmap_3d
             pluginlib
             angles
         )
@@ -65,6 +66,7 @@ catkin_package(
         tf
         pluginlib
         costmap_2d
+        costmap_3d
         nav_core
         angles
 )
@@ -90,6 +92,7 @@ add_library(base_local_planner
 	src/prefer_forward_cost_function.cpp
 	src/point_grid.cpp
 	src/costmap_model.cpp
+	src/costmap_3d_model.cpp
 	src/simple_scored_sampling_planner.cpp
 	src/simple_trajectory_generator.cpp
 	src/trajectory.cpp

--- a/base_local_planner/CMakeLists.txt
+++ b/base_local_planner/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(base_local_planner)
 
+set(CMAKE_CXX_STANDARD 11)
+
 find_package(catkin REQUIRED
         COMPONENTS
             cmake_modules

--- a/base_local_planner/include/base_local_planner/costmap_3d_model.h
+++ b/base_local_planner/include/base_local_planner/costmap_3d_model.h
@@ -1,0 +1,121 @@
+/*********************************************************************
+*
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2019, Badger Technologies LLC
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Willow Garage nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*
+* Author: C. Andy Martin
+*********************************************************************/
+#ifndef TRAJECTORY_ROLLOUT_COSTMAP_3D_MODEL_H_
+#define TRAJECTORY_ROLLOUT_COSTMAP_3D_MODEL_H_
+
+#include <base_local_planner/costmap_model.h>
+// To enable querying costmap 3D
+#include <costmap_3d/costmap_3d_ros.h>
+
+namespace base_local_planner
+{
+
+/**
+ * @class Costmap3DModel
+ * @brief A class that implements the CostmapModel interface to provide
+ * collision checks for the trajectory controller using the Costmap3DROS.
+ */
+class Costmap3DModel : public CostmapModel
+{
+ public:
+  /**
+   * @brief Constructor for the Costmap3DModel
+   * @param costmap The Costmap3DROS to use
+   */
+  Costmap3DModel(costmap_3d::Costmap3DROS& costmap_3d);
+
+  /**
+   * @brief Destructor for the world model
+   */
+  virtual ~Costmap3DModel() {}
+
+  /**
+   * @brief Checks if any obstacles in the 3D costmap lie inside the default 3D footprint
+   *
+   * The caller must have the costmap 3D associated with this object locked
+   * when making this call.
+   *
+   * Since there is no way to pass a 3D footprint model in via this method,
+   * it uses the default model at unity orientation.
+   *
+   * It makes little sense to use this version of this method, unless all the
+   * poses to query have unity orientation.
+   *
+   * @param  position The position of the robot in world coordinates
+   * @param  footprint Ignored
+   * @param  inscribed_radius Ignored
+   * @param  circumscribed_radius Ignored
+   * @return Negative if any obstacle lies within the default 3D footprint
+   */
+  virtual double footprintCost(
+      const geometry_msgs::Point& position,
+      const std::vector<geometry_msgs::Point>& footprint,
+      double inscribed_radius,
+      double circumscribed_radius);
+
+  /**
+   * @brief Checks if any obstacles in the 3D costmap lie inside the default 3D footprint
+   *
+   * The caller must have the costmap 3D associated with this object locked
+   * when making this call.
+   *
+   * Since there is no way to pass a 3D footprint model in via this method,
+   * it uses the default footprint model stored in the Costmap3DROS.
+   *
+   * @param  x The x position of the robot in world coordinates
+   * @param  y The y position of the robot in world coordinates
+   * @param  theta The theta orientation of the robot in world coordinates
+   * @param  footprint_spec Ignored
+   * @param  inscribed_radius Ignored
+   * @param  circumscribed_radius Ignored
+   * @return Negative if any obstacle lies within the default 3D footprint
+   */
+  virtual double footprintCost(
+      double x,
+      double y,
+      double theta,
+      const std::vector<geometry_msgs::Point>& footprint_spec,
+      double inscribed_radius=0.0,
+      double circumscribed_radius=0.0);
+
+ protected:
+  costmap_3d::Costmap3DROS& costmap_3d_; ///< @brief To query 3D costmap
+};
+
+}  // namespace base_local_planner
+
+#endif  // TRAJECTORY_ROLLOUT_COSTMAP_3D_MODEL_H_

--- a/base_local_planner/include/base_local_planner/world_model.h
+++ b/base_local_planner/include/base_local_planner/world_model.h
@@ -62,7 +62,7 @@ namespace base_local_planner {
       virtual double footprintCost(const geometry_msgs::Point& position, const std::vector<geometry_msgs::Point>& footprint,
           double inscribed_radius, double circumscribed_radius) = 0;
 
-      double footprintCost(double x, double y, double theta, const std::vector<geometry_msgs::Point>& footprint_spec, double inscribed_radius = 0.0, double circumscribed_radius=0.0){
+      virtual double footprintCost(double x, double y, double theta, const std::vector<geometry_msgs::Point>& footprint_spec, double inscribed_radius = 0.0, double circumscribed_radius=0.0){
 
         double cos_th = cos(theta);
         double sin_th = sin(theta);

--- a/base_local_planner/package.xml
+++ b/base_local_planner/package.xml
@@ -25,6 +25,7 @@
     <build_depend>rospy</build_depend>
     <build_depend>pluginlib</build_depend>
     <build_depend>costmap_2d</build_depend>
+    <build_depend>costmap_3d</build_depend>
     <build_depend>voxel_grid</build_depend>
     <build_depend>angles</build_depend>
     <build_depend>visualization_msgs</build_depend>
@@ -44,6 +45,7 @@
     <run_depend>rospy</run_depend>
     <run_depend>pluginlib</run_depend>
     <run_depend>costmap_2d</run_depend>
+    <run_depend>costmap_3d</run_depend>
     <run_depend>voxel_grid</run_depend>
     <run_depend>angles</run_depend>
     <run_depend>visualization_msgs</run_depend>

--- a/base_local_planner/src/costmap_3d_model.cpp
+++ b/base_local_planner/src/costmap_3d_model.cpp
@@ -1,0 +1,72 @@
+/*********************************************************************
+*
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2019, Badger Technologies LLC
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Willow Garage nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*
+* Author: C. Andy Martin
+*********************************************************************/
+#include <base_local_planner/costmap_3d_model.h>
+
+namespace base_local_planner
+{
+
+Costmap3DModel::Costmap3DModel(costmap_3d::Costmap3DROS& costmap_3d)
+  :  CostmapModel(*costmap_3d.getCostmap()),
+     costmap_3d_(costmap_3d)
+{
+}
+
+double Costmap3DModel::footprintCost(
+    const geometry_msgs::Point& position,
+    const std::vector<geometry_msgs::Point>& footprint,
+    double inscribed_radius,
+    double circumscribed_radius)
+{
+  // Be sure to warn once that this method was called, as it is unlikely to
+  // be the method that most users will want. We are stuck with this method
+  // due to being a WorldModel.
+  ROS_WARN_ONCE("orientationless footprintCost() called, assuming unity orientation!");
+  return footprintCost(position.x, position.y, 0.0, footprint, inscribed_radius, circumscribed_radius);
+}
+
+double Costmap3DModel::footprintCost(
+    double x,
+    double y,
+    double theta,
+    const std::vector<geometry_msgs::Point>& footprint_spec,
+    double inscribed_radius,
+    double circumscribed_radius)
+{
+  return costmap_3d_.footprintCost(x, y, theta);
+}
+
+}  // end namespace base_local_planner

--- a/clear_costmap_recovery/include/clear_costmap_recovery/clear_costmap_recovery.h
+++ b/clear_costmap_recovery/include/clear_costmap_recovery/clear_costmap_recovery.h
@@ -74,7 +74,6 @@ namespace clear_costmap_recovery{
 
     private:
       void clear(costmap_2d::Costmap2DROS* costmap);      
-      void clearMap(boost::shared_ptr<costmap_2d::CostmapLayer> costmap, double pose_x, double pose_y);
       costmap_2d::Costmap2DROS* global_costmap_, *local_costmap_;
       std::string name_;
       tf::TransformListener* tf_;

--- a/clear_costmap_recovery/src/clear_costmap_recovery.cpp
+++ b/clear_costmap_recovery/src/clear_costmap_recovery.cpp
@@ -112,54 +112,15 @@ void ClearCostmapRecovery::clear(costmap_2d::Costmap2DROS* costmap){
   double x = pose.getOrigin().x();
   double y = pose.getOrigin().y();
 
-  for (std::vector<boost::shared_ptr<costmap_2d::Layer> >::iterator pluginp = plugins->begin(); pluginp != plugins->end(); ++pluginp) {
-    boost::shared_ptr<costmap_2d::Layer> plugin = *pluginp;
-    std::string name = plugin->getName();
-    int slash = name.rfind('/');
-    if( slash != std::string::npos ){
-        name = name.substr(slash+1);
-    }
+  geometry_msgs::Point min, max;
+  min.x = x - reset_distance_ / 2;
+  min.y = y - reset_distance_ / 2;
+  min.z = -std::numeric_limits<double>::max();
+  max.x = x + reset_distance_ / 2;
+  max.y = y + reset_distance_ / 2;
+  max.z = std::numeric_limits<double>::max();
 
-    if(clearable_layers_.count(name)!=0){
-      boost::shared_ptr<costmap_2d::CostmapLayer> costmap;
-      costmap = boost::static_pointer_cast<costmap_2d::CostmapLayer>(plugin);
-      clearMap(costmap, x, y);
-    }
-  }
-}
-
-
-void ClearCostmapRecovery::clearMap(boost::shared_ptr<costmap_2d::CostmapLayer> costmap, 
-                                        double pose_x, double pose_y){
-  boost::unique_lock<costmap_2d::Costmap2D::mutex_t> lock(*(costmap->getMutex()));
- 
-  double start_point_x = pose_x - reset_distance_ / 2;
-  double start_point_y = pose_y - reset_distance_ / 2;
-  double end_point_x = start_point_x + reset_distance_;
-  double end_point_y = start_point_y + reset_distance_;
-
-  int start_x, start_y, end_x, end_y;
-  costmap->worldToMapNoBounds(start_point_x, start_point_y, start_x, start_y);
-  costmap->worldToMapNoBounds(end_point_x, end_point_y, end_x, end_y);
-
-  unsigned char* grid = costmap->getCharMap();
-  for(int x=0; x<(int)costmap->getSizeInCellsX(); x++){
-    bool xrange = x>start_x && x<end_x;
-                   
-    for(int y=0; y<(int)costmap->getSizeInCellsY(); y++){
-      if(xrange && y>start_y && y<end_y){
-	int index = costmap->getIndex(x,y);
-	if(grid[index]!=NO_INFORMATION){
-	  grid[index] = NO_INFORMATION;
-	}
-      }
-    }
-  }
-
-  double ox = costmap->getOriginX(), oy = costmap->getOriginY();
-  double width = costmap->getSizeInMetersX(), height = costmap->getSizeInMetersY();
-  costmap->addExtraBounds(ox, oy, ox + width, oy + height);
-  return;
+  costmap->resetBoundingBox(min, max, clearable_layers_);
 }
 
 };

--- a/costmap_2d/include/costmap_2d/costmap_2d.h
+++ b/costmap_2d/include/costmap_2d/costmap_2d.h
@@ -113,7 +113,7 @@ public:
    * @param my The y coordinate of the cell
    * @return The cost of the cell
    */
-  unsigned char getCost(unsigned int mx, unsigned int my) const;
+  virtual unsigned char getCost(unsigned int mx, unsigned int my) const;
 
   /**
    * @brief  Set the cost of a cell in the costmap
@@ -121,7 +121,7 @@ public:
    * @param my The y coordinate of the cell
    * @param cost The cost to set the cell to
    */
-  void setCost(unsigned int mx, unsigned int my, unsigned char cost);
+  virtual void setCost(unsigned int mx, unsigned int my, unsigned char cost);
 
   /**
    * @brief  Convert from map coordinates to world coordinates
@@ -189,7 +189,7 @@ public:
    * @brief  Will return a pointer to the underlying unsigned char array used as the costmap
    * @return A pointer to the underlying unsigned char array storing cost values
    */
-  unsigned char* getCharMap() const;
+  virtual unsigned char* getCharMap() const;
 
   /**
    * @brief  Accessor for the x size of the costmap in cells
@@ -249,21 +249,21 @@ public:
    * @param cost_value The value to set costs to
    * @return True if the polygon was filled... false if it could not be filled
    */
-  bool setConvexPolygonCost(const std::vector<geometry_msgs::Point>& polygon, unsigned char cost_value);
+  virtual bool setConvexPolygonCost(const std::vector<geometry_msgs::Point>& polygon, unsigned char cost_value);
 
   /**
    * @brief  Get the map cells that make up the outline of a polygon
    * @param polygon The polygon in map coordinates to rasterize
    * @param polygon_cells Will be set to the cells contained in the outline of the polygon
    */
-  void polygonOutlineCells(const std::vector<MapLocation>& polygon, std::vector<MapLocation>& polygon_cells);
+  virtual void polygonOutlineCells(const std::vector<MapLocation>& polygon, std::vector<MapLocation>& polygon_cells);
 
   /**
    * @brief  Get the map cells that fill a convex polygon
    * @param polygon The polygon in map coordinates to rasterize
    * @param polygon_cells Will be set to the cells that fill the polygon
    */
-  void convexFillCells(const std::vector<MapLocation>& polygon, std::vector<MapLocation>& polygon_cells);
+  virtual void convexFillCells(const std::vector<MapLocation>& polygon, std::vector<MapLocation>& polygon_cells);
 
   /**
    * @brief  Move the origin of the costmap to a new location.... keeping data when it can
@@ -276,12 +276,12 @@ public:
    * @brief  Save the costmap out to a pgm file
    * @param file_name The name of the file to save
    */
-  bool saveMap(std::string file_name);
+  virtual bool saveMap(std::string file_name);
 
-  void resizeMap(unsigned int size_x, unsigned int size_y, double resolution, double origin_x,
+  virtual void resizeMap(unsigned int size_x, unsigned int size_y, double resolution, double origin_x,
                  double origin_y);
 
-  void resetMap(unsigned int x0, unsigned int y0, unsigned int xn, unsigned int yn);
+  virtual void resetMap(unsigned int x0, unsigned int y0, unsigned int xn, unsigned int yn);
 
   /**
    * @brief  Given distance in the world... convert it to cells

--- a/costmap_2d/include/costmap_2d/costmap_2d_ros.h
+++ b/costmap_2d/include/costmap_2d/costmap_2d_ros.h
@@ -81,6 +81,8 @@ public:
   Costmap2DROS(std::string name, tf::TransformListener& tf);
   virtual ~Costmap2DROS();
 
+  virtual const std::string& getName() { return name_; }
+
   /**
    * @brief  Subscribes to sensor topics if necessary and starts costmap
    * updates, can be called to restart the costmap after calls to either

--- a/costmap_2d/include/costmap_2d/costmap_2d_ros.h
+++ b/costmap_2d/include/costmap_2d/costmap_2d_ros.h
@@ -286,6 +286,7 @@ private:
   bool map_update_thread_shutdown_;
   bool stop_updates_, initialized_, stopped_, robot_stopped_;
   boost::thread* map_update_thread_;  ///< @brief A thread for updating the map
+  boost::condition_variable_any update_complete_condition_;
   ros::Timer timer_;
   ros::Time last_publish_;
   ros::Duration publish_cycle;

--- a/costmap_2d/include/costmap_2d/costmap_2d_ros.h
+++ b/costmap_2d/include/costmap_2d/costmap_2d_ros.h
@@ -38,6 +38,7 @@
 #ifndef COSTMAP_2D_COSTMAP_2D_ROS_H_
 #define COSTMAP_2D_COSTMAP_2D_ROS_H_
 
+#include <set>
 #include <costmap_2d/layered_costmap.h>
 #include <costmap_2d/layer.h>
 #include <costmap_2d/costmap_2d_publisher.h>
@@ -78,41 +79,53 @@ public:
    * @param tf A reference to a TransformListener
    */
   Costmap2DROS(std::string name, tf::TransformListener& tf);
-  ~Costmap2DROS();
+  virtual ~Costmap2DROS();
 
   /**
    * @brief  Subscribes to sensor topics if necessary and starts costmap
    * updates, can be called to restart the costmap after calls to either
    * stop() or pause()
    */
-  void start();
+  virtual void start();
 
   /**
    * @brief  Stops costmap updates and unsubscribes from sensor topics
    */
-  void stop();
+  virtual void stop();
 
   /**
    * @brief  Stops the costmap from updating, but sensor data still comes in over the wire
    */
-  void pause();
+  virtual void pause();
 
   /**
    * @brief  Resumes costmap updates
    */
-  void resume();
+  virtual void resume();
 
-  void updateMap();
+  virtual void updateMap();
 
   /**
    * @brief Reset each individual layer
    */
-  void resetLayers();
+  virtual void resetLayers();
 
   /** @brief Same as getLayeredCostmap()->isCurrent(). */
-  bool isCurrent()
+  virtual bool isCurrent()
     {
       return layered_costmap_->isCurrent();
+    }
+
+  /** @brief Return if costmap is stopped. */
+  virtual bool isStopped()
+    {
+      return stopped_;
+    }
+
+  /** @brief Return if costmap is paused. */
+  virtual bool isPaused()
+    {
+      return stop_updates_;
     }
 
   /**
@@ -120,12 +133,12 @@ public:
    * @param global_pose Will be set to the pose of the robot in the global frame of the costmap
    * @return True if the pose was set successfully, false otherwise
    */
-  bool getRobotPose(tf::Stamped<tf::Pose>& global_pose) const;
+  virtual bool getRobotPose(tf::Stamped<tf::Pose>& global_pose) const;
 
   /** @brief Return a pointer to the "master" costmap which receives updates from all the layers.
    *
    * Same as calling getLayeredCostmap()->getCostmap(). */
-  Costmap2D* getCostmap()
+  virtual Costmap2D* getCostmap()
     {
       return layered_costmap_->getCostmap();
     }
@@ -134,7 +147,7 @@ public:
    * @brief  Returns the global frame of the costmap
    * @return The global frame of the costmap
    */
-  std::string getGlobalFrameID()
+  virtual std::string getGlobalFrameID()
     {
       return global_frame_;
     }
@@ -143,17 +156,17 @@ public:
    * @brief  Returns the local frame of the costmap
    * @return The local frame of the costmap
    */
-  std::string getBaseFrameID()
+  virtual std::string getBaseFrameID()
     {
       return robot_base_frame_;
     }
-  LayeredCostmap* getLayeredCostmap()
+  virtual LayeredCostmap* getLayeredCostmap()
     {
       return layered_costmap_;
     }
 
   /** @brief Returns the current padded footprint as a geometry_msgs::Polygon. */
-  geometry_msgs::Polygon getRobotFootprintPolygon()
+  virtual geometry_msgs::Polygon getRobotFootprintPolygon()
   {
     return costmap_2d::toPolygon(padded_footprint_);
   }
@@ -166,7 +179,7 @@ public:
    * The footprint initially comes from the rosparam "footprint" but
    * can be overwritten by dynamic reconfigure or by messages received
    * on the "footprint" topic. */
-  std::vector<geometry_msgs::Point> getRobotFootprint()
+  virtual std::vector<geometry_msgs::Point> getRobotFootprint()
   {
     return padded_footprint_;
   }
@@ -178,7 +191,7 @@ public:
    * The footprint initially comes from the rosparam "footprint" but
    * can be overwritten by dynamic reconfigure or by messages received
    * on the "footprint" topic. */
-  std::vector<geometry_msgs::Point> getUnpaddedRobotFootprint()
+  virtual std::vector<geometry_msgs::Point> getUnpaddedRobotFootprint()
   {
     return unpadded_footprint_;
   }
@@ -187,7 +200,7 @@ public:
    * @brief  Build the oriented footprint of the robot at the robot's current pose
    * @param  oriented_footprint Will be filled with the points in the oriented footprint of the robot
    */
-  void getOrientedFootprint(std::vector<geometry_msgs::Point>& oriented_footprint) const;
+  virtual void getOrientedFootprint(std::vector<geometry_msgs::Point>& oriented_footprint) const;
 
   /** @brief Set the footprint of the robot to be the given set of
    * points, padded by footprint_padding.
@@ -199,7 +212,7 @@ public:
    * layered_costmap_->setFootprint().  Also saves the unpadded
    * footprint, which is available from
    * getUnpaddedRobotFootprint(). */
-  void setUnpaddedRobotFootprint(const std::vector<geometry_msgs::Point>& points);
+  virtual void setUnpaddedRobotFootprint(const std::vector<geometry_msgs::Point>& points);
 
   /** @brief Set the footprint of the robot to be the given polygon,
    * padded by footprint_padding.
@@ -211,7 +224,42 @@ public:
    * layered_costmap_->setFootprint().  Also saves the unpadded
    * footprint, which is available from
    * getUnpaddedRobotFootprint(). */
-  void setUnpaddedRobotFootprintPolygon(const geometry_msgs::Polygon& footprint);
+  virtual void setUnpaddedRobotFootprintPolygon(const geometry_msgs::Polygon& footprint);
+
+  /** @brief Lock the master costmap to prevent updates.
+   *
+   * This is important for planners or other users who require a consistent
+   * view over a period of time.
+   *
+   * This class implements the BasicLockable requirements so you can use a
+   * costmap_3d_ros as a template argument to std::lock_guard, for instance.
+   */
+  virtual void lock()
+  {
+    getCostmap()->getMutex()->lock();
+  }
+
+  /** @brief Unlock the master costmap to prevent updates.
+   *
+   * This is important for planners or other users who require a consistent
+   * view over a period of time.
+   *
+   * This class implements the BasicLockable requirements so you can use a
+   * costmap_3d_ros as a template argument to std::lock_guard, for instance.
+   */
+  virtual void unlock()
+  {
+    getCostmap()->getMutex()->unlock();
+  }
+
+  /** @brief Get the names of the layers in the costmap. */
+  virtual std::set<std::string> getLayerNames();
+
+  /** @brief Reset the costmap within the given axis-aligned bounding box in world coordinates across all layers. */
+  virtual void resetBoundingBox(geometry_msgs::Point min, geometry_msgs::Point max);
+
+  /** @brief Reset the costmap within the given axis-aligned bounding box in world coordinates for the given layers. */
+  virtual void resetBoundingBox(geometry_msgs::Point min, geometry_msgs::Point max, const std::set<std::string>& layers);
 
 protected:
   LayeredCostmap* layered_costmap_;

--- a/costmap_2d/include/costmap_2d/costmap_layer.h
+++ b/costmap_2d/include/costmap_2d/costmap_layer.h
@@ -147,7 +147,6 @@ protected:
   void useExtraBounds(double* min_x, double* min_y, double* max_x, double* max_y);
   bool has_extra_bounds_;
 
-private:
   double extra_min_x_, extra_max_x_, extra_min_y_, extra_max_y_;
 };
 

--- a/costmap_2d/include/costmap_2d/costmap_layer.h
+++ b/costmap_2d/include/costmap_2d/costmap_layer.h
@@ -40,6 +40,7 @@
 #include <ros/ros.h>
 #include <costmap_2d/layer.h>
 #include <costmap_2d/layered_costmap.h>
+#include <geometry_msgs/Point.h>
 
 namespace costmap_2d
 {
@@ -68,6 +69,11 @@ public:
    * @param my1 Maximum y value of the bounding box
    */
   void addExtraBounds(double mx0, double my0, double mx1, double my1);
+
+  /**
+   * Reset an axis-aligned bounding box in world coordinates.
+   */
+  void resetBoundingBox(geometry_msgs::Point min, geometry_msgs::Point max);
 
 protected:
   /*

--- a/costmap_2d/src/costmap_2d.cpp
+++ b/costmap_2d/src/costmap_2d.cpp
@@ -234,7 +234,7 @@ void Costmap2D::worldToMapEnforceBounds(double wx, double wy, int& mx, int& my) 
   {
     mx = 0;
   }
-  else if (wx > resolution_ * size_x_ + origin_x_)
+  else if (wx > resolution_ * (size_x_ - 1) + origin_x_)
   {
     mx = size_x_ - 1;
   }
@@ -242,12 +242,14 @@ void Costmap2D::worldToMapEnforceBounds(double wx, double wy, int& mx, int& my) 
   {
     mx = (int)((wx - origin_x_) / resolution_);
   }
+  assert(mx >= 0);
+  assert(mx < size_x_);
 
   if (wy < origin_y_)
   {
     my = 0;
   }
-  else if (wy > resolution_ * size_y_ + origin_y_)
+  else if (wy > resolution_ * (size_y_ - 1) + origin_y_)
   {
     my = size_y_ - 1;
   }
@@ -255,6 +257,8 @@ void Costmap2D::worldToMapEnforceBounds(double wx, double wy, int& mx, int& my) 
   {
     my = (int)((wy - origin_y_) / resolution_);
   }
+  assert(my >= 0);
+  assert(my < size_y_);
 }
 
 void Costmap2D::updateOrigin(double new_origin_x, double new_origin_y)

--- a/costmap_2d/src/costmap_2d_ros.cpp
+++ b/costmap_2d/src/costmap_2d_ros.cpp
@@ -404,6 +404,10 @@ void Costmap2DROS::mapUpdateLoop(double frequency)
         last_publish_ = now;
       }
     }
+
+    // update is complete.
+    update_complete_condition_.notify_all();
+
     r.sleep();
     // make sure to sleep for the remainder of our cycle time
     if (r.cycleTime() > ros::Duration(1 / frequency))
@@ -575,7 +579,8 @@ void Costmap2DROS::resetBoundingBox(geometry_msgs::Point min, geometry_msgs::Poi
 
 void Costmap2DROS::resetBoundingBox(geometry_msgs::Point min, geometry_msgs::Point max, const std::set<std::string>& layers)
 {
-  boost::lock_guard<Costmap2DROS> lock(*this);
+  ROS_INFO_STREAM("Costmap " << name_ << " reset bounding box from " << min << " to " << max);
+  boost::unique_lock<Costmap2DROS> lock(*this);
 
   std::vector < boost::shared_ptr<Layer> > *plugins = layered_costmap_->getPlugins();
   for (vector<boost::shared_ptr<Layer> >::iterator plugin = plugins->begin(); plugin != plugins->end(); ++plugin)
@@ -603,6 +608,20 @@ void Costmap2DROS::resetBoundingBox(geometry_msgs::Point min, geometry_msgs::Poi
         ROS_WARN_STREAM_THROTTLE(5.0, "Unable to clear layer " << (*plugin)->getName() << ": not a CostmapLayer");
       }
     }
+  }
+
+  // Wait until the costmap has updated and is current.
+  // This will keep us from attempting to use a costmap with large regions
+  // blanked out, which is important to prevent from creeping into an
+  // obstacle, or for not getting wacky global plans.
+  for (;;)
+  {
+    update_complete_condition_.wait(lock);
+    if (isCurrent())
+    {
+      break;
+    }
+    ROS_ERROR_STREAM_DELAYED_THROTTLE(5.0, "Costmap " << name_ << " waiting for update after reset");
   }
 }
 

--- a/costmap_2d/src/costmap_2d_ros.cpp
+++ b/costmap_2d/src/costmap_2d_ros.cpp
@@ -37,6 +37,7 @@
  *********************************************************************/
 #include <costmap_2d/layered_costmap.h>
 #include <costmap_2d/costmap_2d_ros.h>
+#include <costmap_2d/costmap_layer.h>
 #include <cstdio>
 #include <string>
 #include <algorithm>
@@ -551,6 +552,58 @@ void Costmap2DROS::getOrientedFootprint(std::vector<geometry_msgs::Point>& orien
   double yaw = tf::getYaw(global_pose.getRotation());
   transformFootprint(global_pose.getOrigin().x(), global_pose.getOrigin().y(), yaw,
                      padded_footprint_, oriented_footprint);
+}
+
+std::set<std::string> Costmap2DROS::getLayerNames()
+{
+  std::set<std::string> rv;
+
+  std::vector < boost::shared_ptr<Layer> > *plugins = layered_costmap_->getPlugins();
+  for (vector<boost::shared_ptr<Layer> >::iterator plugin = plugins->begin(); plugin != plugins->end();
+      ++plugin)
+  {
+    rv.insert((*plugin)->getName());
+  }
+  return rv;
+}
+
+void Costmap2DROS::resetBoundingBox(geometry_msgs::Point min, geometry_msgs::Point max)
+{
+  // No need to reset the master map, as the next update will pull in the changes to each layer.
+  resetBoundingBox(min, max, getLayerNames());
+}
+
+void Costmap2DROS::resetBoundingBox(geometry_msgs::Point min, geometry_msgs::Point max, const std::set<std::string>& layers)
+{
+  boost::lock_guard<Costmap2DROS> lock(*this);
+
+  std::vector < boost::shared_ptr<Layer> > *plugins = layered_costmap_->getPlugins();
+  for (vector<boost::shared_ptr<Layer> >::iterator plugin = plugins->begin(); plugin != plugins->end(); ++plugin)
+  {
+    // Only reset layers that are in the layer set
+    // Match either the whole layer name, or just the final name after the
+    // final '/'.
+    const std::string& plugin_full_name((*plugin)->getName());
+    std::string plugin_last_name_only;
+    int slash = plugin_full_name.rfind('/');
+    if( slash != std::string::npos )
+    {
+      plugin_last_name_only = plugin_full_name.substr(slash+1);
+    }
+    if (layers.find(plugin_full_name) != layers.end()
+        || plugin_last_name_only.size() > 0 && layers.find(plugin_last_name_only) != layers.end())
+    {
+      boost::shared_ptr<CostmapLayer> costmap_layer(boost::dynamic_pointer_cast<CostmapLayer>((*plugin)));
+      if (costmap_layer)
+      {
+        costmap_layer->resetBoundingBox(min, max);
+      }
+      else
+      {
+        ROS_WARN_STREAM_THROTTLE(5.0, "Unable to clear layer " << (*plugin)->getName() << ": not a CostmapLayer");
+      }
+    }
+  }
 }
 
 }  // namespace costmap_2d

--- a/costmap_2d/src/costmap_layer.cpp
+++ b/costmap_2d/src/costmap_layer.cpp
@@ -27,6 +27,22 @@ void CostmapLayer::addExtraBounds(double mx0, double my0, double mx1, double my1
     has_extra_bounds_ = true;
 }
 
+void CostmapLayer::resetBoundingBox(geometry_msgs::Point min, geometry_msgs::Point max)
+{
+  boost::unique_lock<costmap_2d::Costmap2D::mutex_t> lock(*(getMutex()));
+
+  int start_x, start_y, end_x, end_y;
+
+  worldToMapEnforceBounds(min.x, min.y, start_x, start_y);
+  worldToMapEnforceBounds(max.x, max.y, end_x, end_y);
+
+  resetMap(start_x, start_y, end_x, end_y);
+
+  addExtraBounds(min.x, min.y, max.x, max.y);
+  return;
+}
+
+
 void CostmapLayer::useExtraBounds(double* min_x, double* min_y, double* max_x, double* max_y)
 {
     if (!has_extra_bounds_)

--- a/costmap_3d/CMakeLists.txt
+++ b/costmap_3d/CMakeLists.txt
@@ -1,0 +1,144 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(costmap_3d)
+
+set(CMAKE_CXX_STANDARD 11)
+
+find_package(catkin REQUIRED COMPONENTS
+  costmap_2d
+  dynamic_reconfigure
+  actionlib_msgs
+  pluginlib
+  roscpp
+  geometry_msgs
+  octomap_msgs
+  pcl_ros
+  pcl_msgs
+  pcl_conversions
+  tf_conversions
+  message_generation
+)
+
+find_package(OCTOMAP REQUIRED)
+find_package(PCL 1.7 REQUIRED)
+
+# Find FCL (flexible collision library)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(LIBFCL_PC REQUIRED fcl)
+# find *absolute* paths to LIBFCL_INCLUDE_DIRS and LIBFCL_LIBRARIES
+find_path(LIBFCL_INCLUDE_DIRS fcl/config.h HINTS ${LIBFCL_PC_INCLUDE_DIR} ${LIBFCL_PC_INCLUDE_DIRS})
+find_library(LIBFCL_LIBRARIES fcl HINTS ${LIBFCL_PC_LIBRARY_DIRS})
+
+include_directories(
+  include
+  ${OCTOMAP_INCLUDE_DIRS}
+  ${PCL_INCLUDE_DIRS}
+  ${LIBFCL_INCLUDE_DIRS}
+  ${catkin_INCLUDE_DIRS}
+)
+
+generate_dynamic_reconfigure_options(
+  cfg/Costmap3D.cfg
+  cfg/GenericPlugin.cfg
+)
+
+add_action_files(
+  FILES
+  GetPlanCost3D.action
+)
+
+add_service_files(
+  FILES
+  GetPlanCost3DService.srv
+)
+
+generate_messages(
+  DEPENDENCIES
+  actionlib_msgs
+  geometry_msgs
+)
+
+catkin_package(
+  INCLUDE_DIRS
+    include
+  LIBRARIES
+    costmap_3d
+    layers_3d
+  CATKIN_DEPENDS
+    costmap_2d
+    dynamic_reconfigure
+    pluginlib
+    roscpp
+    geometry_msgs
+    octomap_msgs
+    pcl_ros
+    pcl_msgs
+    pcl_conversions
+    tf_conversions
+  DEPENDS
+    OCTOMAP
+    PCL
+    LIBFCL
+)
+
+add_library(costmap_3d
+  src/costmap_3d.cpp
+  src/layer_3d.cpp
+  src/layered_costmap_3d.cpp
+  src/costmap_3d_ros.cpp
+  src/costmap_3d_query.cpp
+  src/costmap_3d_publisher.cpp
+  src/costmap_layer_3d.cpp
+)
+
+target_link_libraries(costmap_3d
+  ${OCTOMAP_LIBRARIES}
+  ${PCL_LIBRARIES}
+  ${LIBFCL_LIBRARIES}
+  ${catkin_LIBRARIES}
+)
+target_compile_options(costmap_3d PRIVATE ${EXTRA_COMPILE_OPTIONS})
+
+add_library(layers_3d
+  plugins/octomap_server_layer_3d.cpp
+  plugins/point_cloud_layer_3d.cpp
+  plugins/costmap_3d_to_2d_layer.cpp
+  plugins/costmap_3d_to_2d_layer_3d.cpp
+)
+
+target_link_libraries(layers_3d
+  costmap_3d
+)
+target_compile_options(layers_3d PRIVATE ${EXTRA_COMPILE_OPTIONS})
+
+add_dependencies(costmap_3d ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+add_dependencies(layers_3d ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+add_executable(costmap_3d_node src/costmap_3d_node.cpp)
+target_link_libraries(costmap_3d_node
+    costmap_3d
+    )
+target_compile_options(costmap_3d_node PRIVATE ${EXTRA_COMPILE_OPTIONS})
+
+## TODO: Configure Tests
+
+install(TARGETS
+    costmap_3d_node
+    DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(TARGETS
+    costmap_3d
+    layers_3d
+    ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+)
+
+install(FILES
+  costmap_2d_plugins.xml
+  costmap_3d_plugins.xml
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+)

--- a/costmap_3d/README.md
+++ b/costmap_3d/README.md
@@ -1,0 +1,52 @@
+Costmap 3D
+==========
+
+The `costmap_3d` package provides a 3D layered costmap based on octomaps.
+
+The `Costmap3DROS` class specializes `Costmap2DROS` to provide smooth
+backwards compatability.
+
+Because the `Costmap3DROS` is a `Costmap2DROS`, it has a 2D costmap associated
+with it, and uses the main 2D layered costmap mutex for synchronizing
+the 3D costmap to keep them consistent with one another. By default, the 2D
+costmap will be empty. However, there are a pair of layer plugins which can be
+used to forward a flattened version of the 3D costmap to the corresponding 2D
+costmap, allowing easy migration into 3D navigation. For instance, some
+planners can be made to use the 3D costmap, while others continue to use the
+2D costmap.
+
+Several example costmap 3d layer plugins are provided, in addition to the
+previously mentioned 3D to 2D conversion layers. An octomap server layer is
+provided which subscribes to octomap updates from an octomap server. The
+corresponding octomap server can integrate many different sources of data
+(point clouds, laser scans), replacing the functionality in the costmap
+2D obstacle layer and static layer. Also, a point cloud layer is provided which
+copies the last point cloud received into a costmap layer, allowing other
+data sources, such as sensor fusion layers, to integrate directly.
+
+In addition to the 3D maps, `Costmap3DROS` provides a querying
+interface in contrast to the 2D costmap. This query interface uses the
+Flexible Collision Library, FCL, to perform queries against a robot mesh and
+the current costmap state. Four types of queries are provided, collision,
+cost, distance and signed distance.
+
+## Caveats
+
+The `badger-develop` branch of `navigation` is required to get the correct
+API changes to `Costmap2DROS` to make it extensible (by making many
+methods virtual, and by adding a few new APIs).
+
+Cost queries are currently unimplemented, and simply return -1.0 for collision
+and 0.0 otherwise.
+
+The `badger-develop` branch of `octomap` is required for `setTreeValues`.
+
+Certain features present in the `badger-develop` branch of `octomap_mapping`
+are used by the octomap costmap layer plugin. The octomap update message
+is used to make efficient map transfer possible from this branch, too.
+
+Many important performance improvements are present in the `badger-develop`
+branch of FCL to make query performance reasonable.
+
+Signed distance queries between octomaps and meshes are not yet functional in
+FCL.

--- a/costmap_3d/action/GetPlanCost3D.action
+++ b/costmap_3d/action/GetPlanCost3D.action
@@ -1,0 +1,55 @@
+# Get the cost of a plan in the 3D costmap.
+# The first two fields are identical to nav_msgs/Path
+Header header
+geometry_msgs/PoseStamped[] poses
+
+# If true, stop as soon as a lethal pose is found.
+# Poses are processed in order, and when a lethal pose is found
+# no further processing is done.
+bool lazy
+
+# If true, run this query on a copy of the costmap, leaving it unlocked
+# after copy. If false, run directly on the master costmap, leaving it locked
+# for the duration of the query.
+bool buffered
+
+# Return costs of each pose as normal
+uint8 COST_QUERY_MODE_COST=0
+# Do not find actual costs, just binary collision information
+uint8 COST_QUERY_MODE_COLLISION_ONLY=1
+# Do not find actual costs, find distances instead
+uint8 COST_QUERY_MODE_DISTANCE=2
+# Do not find actual costs, find exact signed distances instead
+uint8 COST_QUERY_MODE_EXACT_SIGNED_DISTANCE=3
+# Set to one of the above COST_QUERY_MODE_* to control query mode.
+# The default is COST_QUERY_MODE_COST.
+uint8 cost_query_mode
+
+# An alternative footprint_mesh_resource to use (in base_footprint frame)
+# If empty, the default stored in the costmap will be used.
+string footprint_mesh_resource
+
+# How much padding (in meters) to grow the footprint mesh.
+# (negative numbers will shrink the mesh).
+# 0.0 means no padding.
+# NaN means use the default value from the costmap.
+# To precisely control padding, use an alternate mesh, as the generated mesh
+# may pad in a naive way.
+float32 padding
+---
+# The aggregate cost value across the poses.
+# A negative cost value indicates collision.
+# A cost value of 0.0 means no cost.
+# A postive cost value indicates non-zero, yet non-lethal cost.
+# When running in one of the distance modes, the plan_cost will be the minimum
+# distance across all the poses. Note that all forms of distance check will return
+# a negative distance for a collision, but only in the exact signed mode will
+# the negative value be an exact signed distance.
+float64 cost
+# The cost of each pose.
+# When running in one of the distance modes, the "cost" will instead be the
+# distance to the nearest obstacle in meters.
+float64[] pose_costs
+uint32[] lethal_indices
+---
+# no feedback

--- a/costmap_3d/cfg/Costmap3D.cfg
+++ b/costmap_3d/cfg/Costmap3D.cfg
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+from dynamic_reconfigure.parameter_generator_catkin import ParameterGenerator, double_t, int_t, str_t
+
+gen = ParameterGenerator()
+
+#map params
+gen.add("map_z_min", double_t, 0, "The depth (minimum z) of the map in meters.", 0.0)
+gen.add("map_z_max", double_t, 0, "The height (maximum z) of the map in meters.", 2.05)
+
+# robot 3d footprint
+gen.add("footprint_3d_padding", double_t, 0, "How much to pad (increase the size of) the 3D footprint, in meters.", 0.01)
+
+exit(gen.generate("costmap_3d", "costmap_3d", "Costmap3D"))

--- a/costmap_3d/cfg/GenericPlugin.cfg
+++ b/costmap_3d/cfg/GenericPlugin.cfg
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+
+from dynamic_reconfigure.parameter_generator_catkin import ParameterGenerator, bool_t, int_t
+
+gen = ParameterGenerator()
+gen.add("enabled", bool_t, 0, "Whether to apply this plugin or not", True)
+
+combo_enum = gen.enum([ gen.const("Overwrite", int_t,  0, "Overwrite values"),
+                        gen.const("Maximum",   int_t,  1, "Take the maximum of the values"),
+                        gen.const("Nothing",   int_t, 99, "Do nothing")
+                      ],
+                      "Method for combining layers enum")
+
+gen.add("combination_method", int_t, 0, "Method for combining two layers", 1, edit_method=combo_enum)
+
+exit(gen.generate("costmap_3d", "costmap_3d", "GenericPlugin"))

--- a/costmap_3d/costmap_2d_plugins.xml
+++ b/costmap_3d/costmap_2d_plugins.xml
@@ -1,0 +1,7 @@
+<class_libraries>
+  <library path="liblayers_3d">
+    <class type="costmap_3d::Costmap3DTo2DLayer" base_class_type="costmap_2d::Layer">
+      <description>2D costmap layer that tracks 3D costmap updates.</description>
+    </class>
+  </library>
+</class_libraries>

--- a/costmap_3d/costmap_3d_plugins.xml
+++ b/costmap_3d/costmap_3d_plugins.xml
@@ -1,0 +1,13 @@
+<class_libraries>
+  <library path="liblayers_3d">
+    <class type="costmap_3d::Costmap3DTo2DLayer3D" base_class_type="costmap_3d::Layer3D">
+      <description>3D costmap layer that connects the 3D costmap to Costmap3DTo2DLayer instances.</description>
+    </class>
+    <class type="costmap_3d::OctomapServerLayer3D" base_class_type="costmap_3d::Layer3D">
+      <description>Updates a 3D costmap layer from an octomap server.</description>
+    </class>
+    <class type="costmap_3d::PointCloudLayer3D" base_class_type="costmap_3d::Layer3D">
+      <description>Overwrites the 3D costmap layer with the last point cloud received.</description>
+    </class>
+  </library>
+</class_libraries>

--- a/costmap_3d/include/costmap_3d/costmap_3d.h
+++ b/costmap_3d/include/costmap_3d/costmap_3d.h
@@ -1,0 +1,80 @@
+/*********************************************************************
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Badger Technologies LLC
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: C. Andy Martin
+ *********************************************************************/
+#ifndef COSTMAP_3D_COSTMAP_3D_H_
+#define COSTMAP_3D_COSTMAP_3D_H_
+
+#include <memory>
+#include <octomap/octomap.h>
+#include <geometry_msgs/Point.h>
+
+namespace costmap_3d
+{
+
+enum CombinationMethod
+{
+  OVERWRITE = 0,
+  MAXIMUM = 1,
+  NOTHING = 99,
+};
+
+/* OccupancyOcTree Log odds values for various costmap states. */
+typedef float Cost;
+// Sentinel. Don't choose NAN as it can't be pruned in octomap
+const Cost UNKNOWN = -200.0;
+const Cost FREE = -10.0;
+const Cost LETHAL = 10.0;
+/* A log-odds between FREE and LETHAL represents a non-lethal,
+ * but greater than zero cost for that space */
+
+using Costmap3DIndex = octomap::OcTreeKey;
+using Costmap3DIndexEntryType = octomap::key_type;
+
+class Costmap3D : public octomap::OcTree
+{
+public:
+  Costmap3D(double resolution);
+};
+
+typedef std::shared_ptr<Costmap3D> Costmap3DPtr;
+typedef std::shared_ptr<const Costmap3D> Costmap3DConstPtr;
+
+octomap::point3d toOctomapPoint(const geometry_msgs::Point& pt);
+geometry_msgs::Point fromOctomapPoint(const octomap::point3d& point);
+
+}  // namespace costmap_3d
+
+#endif  // COSTMAP_3D_COSTMAP_3D_H_

--- a/costmap_3d/include/costmap_3d/costmap_3d_publisher.h
+++ b/costmap_3d/include/costmap_3d/costmap_3d_publisher.h
@@ -1,0 +1,78 @@
+/*********************************************************************
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Badger Technologies LLC
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: C. Andy Martin
+ *********************************************************************/
+#ifndef COSTMAP_3D_COSTMAP_3D_PUBLISHER_H_
+#define COSTMAP_3D_COSTMAP_3D_PUBLISHER_H_
+
+#include <ros/ros.h>
+#include <costmap_3d/layered_costmap_3d.h>
+#include <octomap_msgs/Octomap.h>
+#include <octomap_msgs/OctomapUpdate.h>
+
+namespace costmap_3d
+{
+
+/**
+ * @class Costmap3DPublisher
+ * @brief A tool to periodically publish visualization data from a LayeredCostmap3D
+ */
+class Costmap3DPublisher
+{
+public:
+  Costmap3DPublisher(const ros::NodeHandle& nh, LayeredCostmap3D* layered_costmap_3d, std::string topic_name);
+
+  ~Costmap3DPublisher();
+
+private:
+  void updateCompleteCallback(LayeredCostmap3D* layered_costmap_3d,
+                              const Costmap3D& delta_map,
+                              const Costmap3D& bounds_map);
+
+  void connectCallback(const ros::SingleSubscriberPublisher& pub);
+  octomap_msgs::OctomapPtr createMapMessage(const Costmap3D& map);
+  octomap_msgs::OctomapUpdatePtr createMapUpdateMessage(const Costmap3D& value_map, const Costmap3D& bounds_map, bool first_map=false);
+
+  std::string update_complete_id;
+  ros::NodeHandle nh_;
+  LayeredCostmap3D* layered_costmap_3d_;
+  ros::Publisher costmap_pub_;
+  ros::Publisher costmap_update_pub_;
+  uint32_t update_seq_;
+};
+
+}  // namespace costmap_3d
+
+#endif  // COSTMAP_3D_COSTMAP_3D_PUBLISHER_H_

--- a/costmap_3d/include/costmap_3d/costmap_3d_query.h
+++ b/costmap_3d/include/costmap_3d/costmap_3d_query.h
@@ -1,0 +1,391 @@
+/*********************************************************************
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Badger Technologies LLC
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: C. Andy Martin
+ *********************************************************************/
+#ifndef COSTMAP_3D_COSTMAP_3D_QUERY_H_
+#define COSTMAP_3D_COSTMAP_3D_QUERY_H_
+
+#include <string>
+#include <memory>
+#include <unordered_map>
+#include <limits>
+#include <fcl/geometry/bvh/BVH_model.h>
+#include <fcl/geometry/shape/utility.h>
+#include <fcl/narrowphase/collision_object.h>
+#include <fcl/narrowphase/distance.h>
+#include <pcl/point_types.h>
+#include <pcl/PolygonMesh.h>
+#include <geometry_msgs/Pose.h>
+#include <tf2/utils.h>
+#include <costmap_3d/layered_costmap_3d.h>
+
+namespace costmap_3d
+{
+
+/** @brief Query a 3D Costmap. */
+class Costmap3DQuery
+{
+public:
+  /**
+   * @brief  Construct a query object associated with a layered costmap 3D.
+   * The query will always be performed on the current layered costmap 3D,
+   * and the corresponding costmap 3D must be locked during queries.
+   */
+  Costmap3DQuery(
+      const LayeredCostmap3D* layered_costmap_3d,
+      const std::string& mesh_resource,
+      double padding = 0.0,
+      unsigned int pose_bins_per_meter = 4,
+      unsigned int pose_bins_per_radian = 4,
+      unsigned int pose_micro_bins_per_meter = 1024,
+      unsigned int pose_micro_bins_per_radian = 1024);
+
+  /**
+   * @brief  Construct a query object on a particular costmap 3D.
+   * This constructor creates an internal copy of the passed costmap
+   * and all queries will be performed on that copy.
+   * This is useful for doing a buffered query.
+   * Note that the costmap in question should not update during the
+   * constructor. If it is the underlying costmap in the LayeredCostmap3D,
+   * be sure to lock the LayeredCostmap3D during construction.
+   */
+  Costmap3DQuery(
+      const Costmap3DConstPtr& costmap_3d,
+      const std::string& mesh_resource,
+      double padding = 0.0,
+      unsigned int pose_bins_per_meter = 4,
+      unsigned int pose_bins_per_radian = 4,
+      unsigned int pose_micro_bins_per_meter = 1024,
+      unsigned int pose_micro_bins_per_radian = 1024);
+
+  /**
+   * Copy constructor.
+   * This is useful to have multiple threads querying the same map.
+   * Query objects are not multi-thread safe, so to query the same
+   * map from multiple threads, create copies of the query objects. The
+   * underlying map is not copied, as std::shared_ptr is used.
+   */
+  Costmap3DQuery(const Costmap3DQuery& rhs);
+
+  virtual ~Costmap3DQuery();
+
+  /** @brief Get the cost to put the robot base at the given pose.
+   *
+   * It is assumed the pose is in the frame of the costmap.
+   * return value represents the cost of the pose
+   * negative is collision, zero is free.
+   * For query objects which track the master layered costmap,
+   * the caller must be holding the lock on the associated costmap. */
+  virtual double footprintCost(geometry_msgs::Pose pose);
+
+  /** @brief Return whether the given pose is in collision.
+   *
+   * It is assumed the pose is in the frame of the costmap.
+   * For query objects which track the master layered costmap,
+   * the caller must be holding the lock on the associated costmap.
+   */
+  virtual bool footprintCollision(geometry_msgs::Pose pose);
+
+  /** @brief Return minimum distance to nearest costmap object.
+   *
+   * It is assumed the pose is in the frame of the costmap.
+   * This returns the minimum unsigned distance. So a collision will return <0.0.
+   * Negative values are not exact minimum distances. If exact minimum is
+   * required use footprintSignedDistance.
+   * For query objects which track the master layered costmap,
+   * the caller must be holding the lock on the associated costmap.
+   */
+  virtual double footprintDistance(geometry_msgs::Pose pose);
+
+  /** @brief Return minimum signed distance to nearest costmap object.
+   *
+   * It is assumed the pose is in the frame of the costmap.
+   * This returns the minimum signed distance. So, the deeper a pose goes into
+   * obstacles, the more negative the return value becomes.
+   * For query objects which track the master layered costmap,
+   * the caller must be holding the lock on the associated costmap.
+   */
+  virtual double footprintSignedDistance(geometry_msgs::Pose pose);
+
+protected:
+  const LayeredCostmap3D* layered_costmap_3d_;
+
+  /** @brief Ensure query map matches currently active costmap.
+   * Note: must be called on every query to ensure that the correct Costmap3D is being queried.
+   * The LayeredCostmap3D can reallocate the Costmap3D, such as when
+   * the resolution changes.
+   * Note: assumes the costmap is locked. The costmap should always be locked
+   * during query calls when this is called.
+   */
+  virtual void checkCostmap();
+
+  /** @brief Update the mesh to use for queries. */
+  virtual void updateMeshResource(const std::string& mesh_resource, double padding = 0.0);
+
+private:
+  // returns path to package file, or empty on error
+  std::string getFileNameFromPackageURL(const std::string& url);
+
+  using FCLFloat = float;
+  using FCLRobotModel = fcl::BVHModel<fcl::OBBRSS<FCLFloat>>;
+  using FCLRobotModelPtr = std::shared_ptr<FCLRobotModel>;
+
+  FCLRobotModelPtr robot_model_;
+
+  using FCLCollisionObject = fcl::CollisionObject<FCLFloat>;
+  using FCLCollisionObjectPtr = std::shared_ptr<FCLCollisionObject>;
+  FCLCollisionObjectPtr robot_obj_;
+
+  std::shared_ptr<const octomap::OcTree> octree_ptr_;
+  FCLCollisionObjectPtr world_obj_;
+  inline const FCLCollisionObjectPtr& getRobotCollisionObject(const geometry_msgs::Pose& pose)
+  {
+    robot_obj_->setTransform(
+        fcl::Transform3<FCLFloat>(
+            fcl::Translation3<FCLFloat>(pose.position.x, pose.position.y, pose.position.z) *
+            fcl::Quaternion<FCLFloat>(pose.orientation.w,
+                                      pose.orientation.x,
+                                      pose.orientation.y,
+                                      pose.orientation.z)));
+
+    return robot_obj_;
+  }
+  inline const FCLCollisionObjectPtr& getWorldCollisionObject() { return world_obj_; }
+
+  // Apply padding to a point coordinate
+  inline FCLFloat padPointCoordinate(FCLFloat c, double padding)
+  {
+    return c > 0.0 ? c + padding : c < 0.0 ? c - padding : c;
+  }
+
+  // Apply padding and convert PCL point to FCL
+  inline fcl::Vector3<FCLFloat> padPCLPointToFCL(const pcl::PointXYZ& p, double padding)
+  {
+    return fcl::Vector3<FCLFloat>(
+        padPointCoordinate(p.x, padding),
+        padPointCoordinate(p.y, padding),
+        padPointCoordinate(p.z, padding));
+  }
+
+  // Add fcl triangles to the mesh vector for all triangles in a PCL polygon
+  void addPCLPolygonToFCLTriangles(
+      const pcl::Vertices& polygon,
+      std::vector<fcl::Triangle>* fcl_triangles);
+
+  // Add a padded PCL mesh into the given robot model
+  void addPCLPolygonMeshToRobotModel(
+      const pcl::PolygonMesh& pcl_mesh,
+      double padding,
+      FCLRobotModel* robot_model);
+
+  class DistanceCacheKey
+  {
+  public:
+    DistanceCacheKey(const geometry_msgs::Pose& pose, int bins_per_meter, int bins_per_radian)
+    {
+      binned_pose_ = binPose(pose, bins_per_meter, bins_per_radian);
+    }
+
+    size_t hash_value() const
+    {
+      size_t rv = 0;
+      hash_combine(rv, binned_pose_.orientation.x);
+      hash_combine(rv, binned_pose_.orientation.y);
+      hash_combine(rv, binned_pose_.orientation.z);
+      hash_combine(rv, binned_pose_.orientation.w);
+      hash_combine(rv, binned_pose_.position.x);
+      hash_combine(rv, binned_pose_.position.y);
+      hash_combine(rv, binned_pose_.position.z);
+      return rv;
+    }
+
+    bool operator==(const DistanceCacheKey& rhs) const
+    {
+      return binned_pose_.orientation.x == rhs.binned_pose_.orientation.x &&
+             binned_pose_.orientation.y == rhs.binned_pose_.orientation.y &&
+             binned_pose_.orientation.z == rhs.binned_pose_.orientation.z &&
+             binned_pose_.orientation.w == rhs.binned_pose_.orientation.w &&
+             binned_pose_.position.x == rhs.binned_pose_.position.x &&
+             binned_pose_.position.y == rhs.binned_pose_.position.y &&
+             binned_pose_.position.z == rhs.binned_pose_.position.z;
+    }
+
+  protected:
+    geometry_msgs::Pose binned_pose_;
+
+    //! Borrow boost's hash_combine directly to avoid having to pull in boost
+    template <class T>
+    inline void hash_combine(std::size_t& seed, const T& v) const
+    {
+      std::hash<T> hasher;
+      seed ^= hasher(v) + 0x9e3779b9 + (seed<<6) + (seed>>2);
+    }
+
+    // Bin a pose.
+    inline geometry_msgs::Pose binPose(const geometry_msgs::Pose& pose,
+                                       int bins_per_meter,
+                                       int bins_per_radian)
+    {
+      geometry_msgs::Pose rv;
+      rv.position.x = std::round(pose.position.x * bins_per_meter) / bins_per_meter;
+      rv.position.y = std::round(pose.position.y * bins_per_meter) / bins_per_meter;
+      rv.position.z = std::round(pose.position.z * bins_per_meter) / bins_per_meter;
+      // bin orientation by RPY angles.
+      // another way of binning would be binning by axis/angle
+      double yaw, pitch, roll;
+      tf2::getEulerYPR<geometry_msgs::Quaternion>(pose.orientation, yaw, pitch, roll);
+      yaw = std::round(yaw * bins_per_radian) / bins_per_radian;
+      pitch = std::round(pitch * bins_per_radian) / bins_per_radian;
+      roll = std::round(roll * bins_per_radian) / bins_per_radian;
+      tf2::Quaternion binned_q;
+      binned_q.setRPY(roll, pitch, yaw);
+      rv.orientation = tf2::toMsg(binned_q);
+      return rv;
+    }
+  };
+
+  struct DistanceCacheKeyHash
+  {
+    size_t operator()(const DistanceCacheKey& key) const
+    {
+      return key.hash_value();
+    }
+  };
+
+  struct DistanceCacheKeyEqual
+  {
+    bool operator()(const DistanceCacheKey& lhs, const DistanceCacheKey& rhs) const
+    {
+      return lhs == rhs;
+    }
+  };
+
+  class DistanceCacheEntry
+  {
+  public:
+    DistanceCacheEntry() {}
+    DistanceCacheEntry(const DistanceCacheEntry& rhs)
+        : octomap_box(rhs.octomap_box),
+          octomap_box_tf(rhs.octomap_box_tf),
+          mesh_triangle(rhs.mesh_triangle)
+    {
+    }
+    const DistanceCacheEntry& operator=(const DistanceCacheEntry& rhs)
+    {
+      octomap_box = rhs.octomap_box;
+      octomap_box_tf = rhs.octomap_box_tf;
+      mesh_triangle = rhs.mesh_triangle;
+      return *this;
+    }
+    DistanceCacheEntry(const fcl::DistanceResult<FCLFloat>& result)
+    {
+      assert(result.primitive1);
+      assert(result.primitive2);
+      octomap_box = std::dynamic_pointer_cast<fcl::Box<FCLFloat>>(result.primitive1);
+      octomap_box_tf = result.tf1;
+      mesh_triangle = std::dynamic_pointer_cast<fcl::TriangleP<FCLFloat>>(result.primitive2);
+      assert(octomap_box);
+      assert(mesh_triangle);
+    }
+    void setupResult(fcl::DistanceResult<FCLFloat>* result)
+    {
+      result->primitive1 = octomap_box;
+      result->primitive2 = mesh_triangle;
+      result->tf1 = octomap_box_tf;
+    }
+    FCLFloat distanceToNewPose(geometry_msgs::Pose pose)
+    {
+      // Turn pose into tf
+      fcl::Transform3<FCLFloat> new_tf(
+          fcl::Translation3<FCLFloat>(pose.position.x, pose.position.y, pose.position.z) *
+          fcl::Quaternion<FCLFloat>(pose.orientation.w,
+                                    pose.orientation.x,
+                                    pose.orientation.y,
+                                    pose.orientation.z));
+
+      FCLFloat dist;
+      fcl::detail::GJKSolver_libccd<FCLFloat> solver;
+      fcl::Vector3<FCLFloat> p1, p2;
+      solver.shapeTriangleDistance(*octomap_box, octomap_box_tf,
+                                   mesh_triangle->a, mesh_triangle->b, mesh_triangle->c, new_tf,
+                                   &dist, &p1, &p2);
+      return dist;
+    }
+    std::shared_ptr<fcl::Box<FCLFloat>> octomap_box;
+    fcl::Transform3<FCLFloat> octomap_box_tf;
+    std::shared_ptr<fcl::TriangleP<FCLFloat>> mesh_triangle;
+  };
+  using DistanceCache = std::unordered_map<DistanceCacheKey, DistanceCacheEntry, DistanceCacheKeyHash, DistanceCacheKeyEqual>;
+  /**
+   * The distance cache allows us to find a very good distance guess quickly.
+   * The cache memorizes to a hash table for a pose rounded to the number of
+   * bins the mesh triangle and octomap box pair for the last distance query
+   * in that pose bin. The distance is recalculated with the new pose, and
+   * used as the starting guess to radically prune the search tree for
+   * distance queries. This results in no loss of correctness and a huge
+   * speed-up when distance queries are over the same space.
+   */
+  DistanceCache distance_cache_;
+  /**
+   * The micro-distance cache allows us to return a guess as to the distance
+   * based on hitting the micro-cache. The number of bins in the micro-cache
+   * must be large to prevent gross error. If the micro-cache is hit on a
+   * distance query, instead of making a query, the cached triangle is
+   * transformed to the new pose, and the distance between that triangle and
+   * the previous octomap box is returned immediately. This results in a
+   * massive speed-up when querying very small changes in pose (which may
+   * be done to calculate derivatives, for instance). Do note that this
+   * cache is a potential source of minor error, so in cases where that is
+   * important use a very high number of bins (which will reduce its
+   * efficiency for the sake of accuracy).
+   */
+  DistanceCache micro_distance_cache_;
+  unsigned int last_layered_costmap_update_number_;
+  //! Distance cache bins per meter for binning the pose's position
+  unsigned int pose_bins_per_meter_;
+  //! Distance cache bins per radian for binning the pose's orientation
+  unsigned int pose_bins_per_radian_;
+  //! Micro-distance cache bins per meter for binning the pose's position
+  unsigned int pose_micro_bins_per_meter_;
+  //! Micro-distance cache bins per radian for binning the pose's position
+  unsigned int pose_micro_bins_per_radian_;
+};
+
+using Costmap3DQueryPtr = std::shared_ptr<Costmap3DQuery>;
+using Costmap3DQueryConstPtr = std::shared_ptr<const Costmap3DQuery>;
+
+}  // namespace costmap_3d
+
+#endif  // COSTMAP_3D_COSTMAP_3D_QUERY_H_

--- a/costmap_3d/include/costmap_3d/costmap_3d_ros.h
+++ b/costmap_3d/include/costmap_3d/costmap_3d_ros.h
@@ -1,0 +1,262 @@
+/*********************************************************************
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Badger Technologies LLC
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: C. Andy Martin
+ *********************************************************************/
+#ifndef COSTMAP_3D_COSTMAP_3D_ROS_H_
+#define COSTMAP_3D_COSTMAP_3D_ROS_H_
+
+#include <string>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <ros/ros.h>
+#include <actionlib/server/simple_action_server.h>
+#include <costmap_2d/costmap_2d_ros.h>
+#include <costmap_3d/layered_costmap_3d.h>
+#include <costmap_3d/costmap_3d_publisher.h>
+#include <costmap_3d/costmap_3d_query.h>
+#include <costmap_3d/GetPlanCost3DAction.h>
+#include <costmap_3d/GetPlanCost3DService.h>
+#include <costmap_3d/Costmap3DConfig.h>
+#include <dynamic_reconfigure/server.h>
+#include <pluginlib/class_loader.h>
+
+namespace costmap_3d
+{
+
+/** @brief A ROS wrapper for a 3D Costmap. */
+class Costmap3DROS : public costmap_2d::Costmap2DROS
+{
+  using super = costmap_2d::Costmap2DROS;
+public:
+  /**
+   * @brief  Constructor for the wrapper
+   * @param name The name for this costmap
+   * @param tf A reference to a TransformListener
+   */
+  Costmap3DROS(std::string name, tf::TransformListener& tf);
+  virtual ~Costmap3DROS();
+
+  /**
+   * @brief  Subscribes to sensor topics if necessary and starts costmap
+   * updates, can be called to restart the costmap after calls to either
+   * stop() or pause()
+   */
+  virtual void start();
+
+  /**
+   * @brief  Stops costmap updates and unsubscribes from sensor topics
+   */
+  virtual void stop();
+
+  /** @brief Update the costmap from all layers, publishing as necessary. */
+  virtual void updateMap();
+
+  /**
+   * @brief Reset all layers
+   */
+  virtual void resetLayers();
+
+  /** @brief Returns true if all layers have current sensor data. */
+  virtual bool isCurrent()
+  {
+    return super::isCurrent() && layered_costmap_3d_.isCurrent();
+  }
+
+  /* Unlike Costmap2D, provide no interface to the 3D layered costmap internals.
+   * Instead provide specific interfaces to clear 3D layers and get 3D collision
+   * information from the map. Note that altering the included 2D master
+   * costmap has no effect on the 3D data. The 3D costmap may be mirrored to
+   * the 2D costmap using the costmap3DTo2D plugin. */
+
+  /** @brief Get a buffered query object associated with a copy of our costmap.
+   * Note: it is assumed that this object is not locked, as the lock is
+   * acquired automatically.
+   */
+  virtual std::shared_ptr<Costmap3DQuery> getBufferedQuery(
+          const std::string& footprint_mesh_resource = "",
+          double padding = NAN);
+
+  /** @brief Get a query object associated with our layered costmap.
+   * Note: it is up to the caller to ensure the costmap is properly
+   * locked while executing queries, or unpredictable behavior will occur!
+   */
+  virtual std::shared_ptr<Costmap3DQuery> getAssociatedQuery(
+          const std::string& footprint_mesh_resource = "",
+          double padding = NAN);
+
+  /** @brief Get the names of the layers (both 2D and 3D) in the costmap. */
+  virtual std::set<std::string> getLayerNames();
+
+  // Be sure to have all versions of resetBoundingBox from parent referencable
+  using super::resetBoundingBox;
+
+  /** @brief Reset the costmap within the given axis-aligned bounding box in world coordinates for the given layers. */
+  virtual void resetBoundingBox(geometry_msgs::Point min, geometry_msgs::Point max, const std::set<std::string>& layers);
+
+  /** @brief Get the cost to put the robot base at the given pose in the 3D costmap.
+   *
+   * This call only checks the layered 3D costmap. Any 2D layers are ignored.
+   *
+   * It is assumed the pose is in the frame of the costmap, and the current
+   * state of the costmap is queried at the given pose.
+   * Currently the padding is applied in all directions.
+   *
+   * The caller must be holding the lock.
+   *
+   * @param pose                    pose to query
+   * @param footprint_mesh_resource which footprint mesh to use, empty string means default
+   * @param padding                 padding to add to the footprint. NAN means use default padding
+   *
+   * @returns negative for lethal, otherwise the cost of the pose */
+  virtual double footprintCost(geometry_msgs::Pose pose,
+                               const std::string& footprint_mesh_resource = "",
+                               double padding = NAN);
+
+  virtual double footprintCost(double x, double y, double theta,
+                               const std::string& footprint_mesh_resource = "",
+                               double padding = NAN)
+  {
+    geometry_msgs::Pose pose;
+    pose.position.x = x;
+    pose.position.y = y;
+    pose.orientation = tf::createQuaternionMsgFromYaw(theta);
+    return footprintCost(pose, footprint_mesh_resource, padding);
+  }
+
+  /** @brief Return whether the given pose is in collision in the 3D costmap.
+   *
+   * This call only checks the layered 3D costmap. Any 2D layers are ignored.
+   *
+   * The caller must be holding the lock.
+   *
+   * @param pose                    pose to query
+   * @param footprint_mesh_resource which footprint mesh to use, empty string means default
+   * @param padding                 padding to add to the footprint. NAN means use default padding
+   *
+   * @returns true if in collision, false otherwise */
+  virtual bool footprintCollision(geometry_msgs::Pose pose,
+                                  const std::string& footprint_mesh_resource = "",
+                                  double padding = NAN);
+
+  /** @brief Return minimum distance to the nearest lethal 3D costmap object.
+   * This returns the minimum unsigned distance or negative on a collision.
+   * Negative values are not exact minimum distances. If exact minimum is
+   * required use footprintSignedDistance.
+   *
+   * This call only checks the layered 3D costmap. Any 2D layers are ignored.
+   *
+   * The caller must be holding the lock.
+   *
+   * @param pose                    pose to query
+   * @param footprint_mesh_resource which footprint mesh to use, empty string means default
+   * @param padding                 padding to add to the footprint. NAN means use default padding
+   *
+   * @returns negative on collision, otherwise distance to nearest obstacle */
+  virtual double footprintDistance(geometry_msgs::Pose pose,
+                                   const std::string& footprint_mesh_resource = "",
+                                   double padding = NAN);
+
+  /** @brief Return minimum signed distance to nearest 3D costmap object.
+   * This returns the minimum signed distance. So, the deeper a pose goes into
+   * obstacles, the more negative the return value becomes.
+   * The caller must be holding the lock.
+   *
+   * This call only checks the layered 3D costmap. Any 2D layers are ignored.
+   *
+   * @param pose                    pose to query
+   * @param footprint_mesh_resource which footprint mesh to use, empty string means default
+   * @param padding                 padding to add to the footprint. NAN means use default padding
+   *
+   * @returns exact signed distance to nearest obstacle */
+  virtual double footprintSignedDistance(geometry_msgs::Pose pose,
+                                         const std::string& footprint_mesh_resource = "",
+                                         double padding = NAN);
+
+protected:
+  ros::NodeHandle private_nh_;
+  LayeredCostmap3D layered_costmap_3d_;
+
+private:
+  // Because the parent class starts a thread calling updateMap right away,
+  // keep track if we are fully initialized to prevent doing anything with a
+  // partially constructed object.
+  std::mutex initialized_mutex_;
+  bool initialized_;
+  void reconfigureCB(costmap_3d::Costmap3DConfig &config, uint32_t level);
+  pluginlib::ClassLoader<Layer3D> plugin_loader_;
+  Costmap3DPublisher publisher_;
+  ros::Publisher footprint_pub_;
+  dynamic_reconfigure::Server<costmap_3d::Costmap3DConfig> dsrv_;
+  actionlib::SimpleActionServer<GetPlanCost3DAction> get_plan_cost_action_srv_;
+  ros::ServiceServer get_plan_cost_srv_;
+
+  void getPlanCost3DActionCallback(const actionlib::SimpleActionServer<GetPlanCost3DAction>::GoalConstPtr& goal);
+  bool getPlanCost3DServiceCallback(GetPlanCost3DService::Request& request, GetPlanCost3DService::Response& response);
+  template <typename RequestType, typename ResponseType>
+  void processPlanCost3D(RequestType& request, ResponseType& response);
+
+  // turn this into a map of pairs of string, double => Costmap3DQuery
+  // use a rw lock on it to speed up multi-thread
+  // change (or extend?) the query class to *track* the costmap via subscribing to the delta updates (in process) have
+  // it detect a loss of sync and resubscribe just like the costmap itself.
+  // this way queries do not requiring locking the master costmap.
+  //
+  // Or, instead of different queries for each mesh, add an interface by which
+  // a caller can get a reference to their own query object. Leave the current
+  // direct-querying intact, as this may be important for feasability checks.
+  // But a direct query object would have its own subscription to the costmap,
+  // and its own copies of the mesh/models, and its own current mesh/padding
+  // so other queries don't interfere w/ that client.
+  // Create query objects for each call.
+  // Add an interface to the query object to lock the query object so the map doesn't update
+  // Query objects themselves could buffer the various models that have been
+  // used on that object directly to speed up switching models?
+  using QueryMap = std::map<std::pair<std::string, double>, std::shared_ptr<Costmap3DQuery>>;
+  QueryMap query_map_;
+  const std::string& getFootprintMeshResource(const std::string& alt_mesh);
+  double getFootprintPadding(double alt_padding);
+  // assumes costmap is locked
+  std::shared_ptr<Costmap3DQuery> getQuery(const std::string& footprint_mesh_resource, double padding);
+  void publishFootprint();
+
+  std::string footprint_mesh_resource_;
+  double footprint_3d_padding_;
+
+};
+// class Costmap3DROS
+}  // namespace costmap_3d
+
+#endif  // COSTMAP_3D_COSTMAP_3D_ROS_H_

--- a/costmap_3d/include/costmap_3d/costmap_3d_to_2d_layer.h
+++ b/costmap_3d/include/costmap_3d/costmap_3d_to_2d_layer.h
@@ -1,0 +1,83 @@
+/*********************************************************************
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Badger Technologies LLC
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: C. Andy Martin
+ *********************************************************************/
+#ifndef COSTMAP_3D_COSTMAP_3D_TO_2D_LAYER_H_
+#define COSTMAP_3D_COSTMAP_3D_TO_2D_LAYER_H_
+
+#include <memory>
+#include <unordered_map>
+#include <ros/ros.h>
+#include <costmap_2d/costmap_layer.h>
+#include <costmap_2d/layered_costmap.h>
+#include <costmap_3d/GenericPluginConfig.h>
+#include <dynamic_reconfigure/server.h>
+#include <costmap_3d/layered_costmap_3d.h>
+
+namespace costmap_3d
+{
+
+class Costmap3DTo2DLayer : public costmap_2d::CostmapLayer
+{
+  using super = costmap_2d::CostmapLayer;
+public:
+  Costmap3DTo2DLayer();
+  virtual ~Costmap3DTo2DLayer();
+  virtual void onInitialize();
+  virtual void activate();
+  virtual void deactivate();
+  virtual void reset();
+
+  virtual void updateBounds(double robot_x, double robot_y, double robot_yaw, double* min_x, double* min_y,
+                            double* max_x, double* max_y);
+  virtual void updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, int min_j, int max_i, int max_j);
+
+  virtual void matchSize();
+
+  /// Apply a 3D costmap update to our 2D costmap.
+  virtual void updateFrom3D(LayeredCostmap3D* layered_costmap_3d, const Costmap3D& delta, const Costmap3D& bounds_map);
+
+protected:
+  unsigned char toCostmap2D(Cost value) const;
+  void reconfigureCB(costmap_3d::GenericPluginConfig &config, uint32_t level);
+  std::shared_ptr<dynamic_reconfigure::Server<costmap_3d::GenericPluginConfig>> dsrv_;
+  bool use_maximum_;
+  bool copy_full_map_;
+  LayeredCostmap3D* layered_costmap_3d_;
+};
+
+}  // namespace costmap_2d
+
+#endif  // COSTMAP_3D_COSTMAP_3D_TO_2D_LAYER_H_

--- a/costmap_3d/include/costmap_3d/costmap_3d_to_2d_layer_3d.h
+++ b/costmap_3d/include/costmap_3d/costmap_3d_to_2d_layer_3d.h
@@ -1,0 +1,76 @@
+/*********************************************************************
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Badger Technologies LLC
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: C. Andy Martin
+ *********************************************************************/
+#ifndef COSTMAP_3D_COSTMAP_3D_TO_2D_LAYER_3D_H_
+#define COSTMAP_3D_COSTMAP_3D_TO_2D_LAYER_3D_H_
+
+#include <costmap_3d/costmap_3d.h>
+#include <costmap_3d/layered_costmap_3d.h>
+#include <string>
+
+namespace costmap_3d
+{
+
+/**
+ * Interface to glue a 3D costmap to a 2D costmap layer.
+ * Note that both layers must be in the same Costmap3DROS to work.
+ */
+class Costmap3DTo2DLayer3D : public Layer3D
+{
+  using super = Layer3D;
+public:
+  Costmap3DTo2DLayer3D();
+  virtual ~Costmap3DTo2DLayer3D();
+
+  virtual void updateBounds(const geometry_msgs::Pose robot_pose,
+                            const geometry_msgs::Point& rolled_min,
+                            const geometry_msgs::Point& rolled_max,
+                            Costmap3D* bounds_map) {}
+
+  virtual void updateCosts(const Costmap3D& bounds_map, Costmap3D* master_map) {}
+
+  virtual void initialize(LayeredCostmap3D* parent, std::string name, tf::TransformListener *tf);
+  virtual void deactivate();
+  virtual void activate();
+  virtual void reset() {}
+  virtual void resetBoundingBox(geometry_msgs::Point min_point, geometry_msgs::Point max_point) {}
+  virtual bool isCurrent() const {return true;}
+  virtual void matchSize(const geometry_msgs::Point& min, const geometry_msgs::Point& max, double resolution) {}
+};
+
+}  // namespace costmap_3d
+
+#endif  // COSTMAP_3D_COSTMAP_3D_TO_2D_LAYER_3D_H_

--- a/costmap_3d/include/costmap_3d/costmap_layer_3d.h
+++ b/costmap_3d/include/costmap_3d/costmap_layer_3d.h
@@ -1,0 +1,213 @@
+/*********************************************************************
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Badger Technologies LLC
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: C. Andy Martin
+ *********************************************************************/
+#ifndef COSTMAP_3D_COSTMAP_LAYER_3D_H_
+#define COSTMAP_3D_COSTMAP_LAYER_3D_H_
+
+#include <limits>
+#include <costmap_3d/costmap_3d.h>
+#include <costmap_3d/layered_costmap_3d.h>
+#include <costmap_3d/layer_3d.h>
+#include <geometry_msgs/Point.h>
+
+namespace costmap_3d
+{
+
+class LayeredCostmap3D;
+
+class CostmapLayer3D : public Layer3D
+{
+  using super = Layer3D;
+public:
+  CostmapLayer3D();
+  virtual ~CostmapLayer3D();
+
+  /** @brief Add nodes to bounds_map for any cells that have changed
+   *
+   * The point of updateBounds is to accumulate all the space that has
+   * changed in all layers since the last costmap update. For convenience, the
+   * changed space is represented as lethal occupied (even though all we are
+   * storing here is really a bit that means we should update this space).
+   * This layer should call updateNode(node, LETHAL) for every leaf
+   * node that has changed since the last update.
+   *
+   * Also, for rolling maps, layers should check for data that is outside the
+   * current rolled min/max that is passed in. For non-rolling maps, layers
+   * may assume the bounds only change when matchSize() is called.
+   * Note that layers do not need to put out-of-bounds cells into the
+   * bounds_map. The layered costmap will delete out-of-bounds cells from the
+   * master map and manage tracking their removal for publishing. It will not
+   * hurt anything to put the cells in the bounds map, it is just unnecessary.
+   */
+  virtual void updateBounds(const geometry_msgs::Pose robot_pose,
+                            const geometry_msgs::Point& rolled_min,
+                            const geometry_msgs::Point& rolled_max,
+                            Costmap3D* bounds_map);
+
+  /** @brief Copy the state of this costmap layer into the master layer using
+   * the bounds_map to limit what portion is copied.
+   *
+   * The point of updateCosts is to efficiently update the master layer
+   * using the update policy (update with max, or update with overwrite, or
+   * true overwrite).
+   *
+   * The layered costmap using this plugin must have acquired the lock, and
+   * must hold it across the call to updateBounds and updateCosts. This will
+   * prevent our costmap from changing while copying to the master costmap.
+   *
+   * The default implementation will work fine as long as the internal costmap
+   * is kept up to date. Be sure to prevent the internal costmap_ and
+   * changed_cells_ from changing state between the call to updateBounds and
+   * updateCosts.
+   */
+  virtual void updateCosts(const Costmap3D& bounds_map, Costmap3D* master_map);
+
+  /** @brief Deactivate this layer.
+   *
+   * The default implementation will work fine if the layer is storing its
+   * costmap in the costmap_ member.
+   */
+  virtual void deactivate();
+
+  /** @brief Activate this layer. */
+  virtual void activate();
+
+  /** @brief Forget all memory as if restarting */
+  virtual void reset();
+
+  /**
+   * @brief Forget old sensor data within the given axis-aligned bounding box.
+   *
+   * For plugins which have no persistent memory of their own but make use of
+   * the costmap_, there is no need to override this method.
+   */
+  virtual void resetBoundingBox(Costmap3DIndex min, Costmap3DIndex max);
+
+  virtual void resetBoundingBox(geometry_msgs::Point min_point, geometry_msgs::Point max_point);
+
+  virtual void matchSize(const geometry_msgs::Point& min, const geometry_msgs::Point& max, double resolution);
+
+protected:
+  virtual void resetBoundingBoxUnlocked(Costmap3DIndex min, Costmap3DIndex max);
+
+  /** @brief Touch all the cells present in the given OcTree.
+   * This layer must be holding the lock to make this call. */
+  virtual void touch(const octomap::OcTree& touch_map);
+
+  /** @brief Touch the given index.
+   * This layer must be holding the lock to make this call. */
+  virtual void touch(const Costmap3DIndex& key);
+
+  /** @brief Touch the given key at the given depth.
+   * This layer must be holding the lock to make this call. */
+  virtual void touchKeyAtDepth(const octomap::OcTreeKey& key,
+                               unsigned int depth=std::numeric_limits<unsigned int>::max());
+
+  /** @brief Update the cells in binary fashion from the given values and bounds. */
+  virtual void updateCells(const octomap::OcTree& value_map, const octomap::OcTree& bounds_map,
+                           Cost occupied_threshold = LETHAL);
+
+  /** @brief Update the cell at the given point.
+   * If mark is true, mark the cell, otherwise clear it.
+   * This layer must be holding the lock to make this call. */
+  virtual void updateCell(const geometry_msgs::Point& point, bool mark=false);
+
+  /** @brief Update the cell at the given key.
+   * If mark is true, mark the cell, otherwise clear it.
+   * This layer must be holding the lock to make this call. */
+  virtual void updateCell(const octomap::OcTreeKey& key, bool mark=false);
+
+  /** @brief Mark the cell at the given point.
+   * This layer must be holding the lock to make this call. */
+  virtual void markCell(const geometry_msgs::Point& point);
+
+  /** @brief Mark the cell at the given key.
+   * This layer must be holding the lock to make this call. */
+  virtual void markCell(const octomap::OcTreeKey& key);
+
+  /** @brief Clear the cell at the given point.
+   * This layer must be holding the lock to make this call. */
+  virtual void clearCell(const geometry_msgs::Point& point);
+
+  /** @brief Clear the cell at the given key.
+   * This layer must be holding the lock to make this call. */
+  virtual void clearCell(const octomap::OcTreeKey& key);
+
+  /** @brief Mark and clear cells from the given Costmap3D.
+   *
+   * This copies the given Costmap3D into this layer, overwriting any
+   * overlapping cells with the costs in the passed in map.
+   *
+   * This layer must be holding the lock to make this call. */
+  virtual void markAndClearCells(const Costmap3D& map);
+
+  /** @brief Erase the cell at the given point.
+   * This layer must be holding the lock to make this call. */
+  virtual void eraseCell(const geometry_msgs::Point& point);
+
+  /** @brief Erase the cell at the given key.
+   * This layer must be holding the lock to make this call. */
+  virtual void eraseCell(const octomap::OcTreeKey& key);
+
+  /** @brief Erase the cells from this layer that exist in given map.
+   *
+   * Erase the cells in this costmap layer that exist in the passed in map.
+   *
+   * This layer must be holding the lock to make this call. */
+  virtual void eraseCells(const Costmap3D& map);
+
+  /** @brief Set the cell cost at the given key and depth.
+   * This layer must be holding the lock to make this call. */
+  virtual void setCellCostAtDepth(const octomap::OcTreeKey& key, Cost cost,
+                                  unsigned int depth=std::numeric_limits<unsigned int>::max());
+
+  /** @brief Set the cell cost at the given key.
+   * This layer must be holding the lock to make this call. */
+  virtual void setCellCost(const octomap::OcTreeKey& key, Cost cost);
+
+  /** @brief Set the cell cost at the given point.
+   * This layer must be holding the lock to make this call. */
+  virtual void setCellCost(const geometry_msgs::Point& point, Cost cost);
+
+  Costmap3DPtr costmap_;
+  Costmap3DPtr changed_cells_;
+  bool enabled_;
+  int combination_method_;
+};
+
+}  // namespace costmap_3d
+
+#endif  // COSTMAP_3D_COSTMAP_LAYER_3D_H_

--- a/costmap_3d/include/costmap_3d/layer_3d.h
+++ b/costmap_3d/include/costmap_3d/layer_3d.h
@@ -1,0 +1,155 @@
+/*********************************************************************
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Badger Technologies LLC
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: C. Andy Martin
+ *********************************************************************/
+#ifndef COSTMAP_3D_LAYER_3D_H_
+#define COSTMAP_3D_LAYER_3D_H_
+
+#include <costmap_3d/costmap_3d.h>
+#include <costmap_3d/layered_costmap_3d.h>
+#include <string>
+#include <tf/tf.h>
+#include <tf/transform_listener.h>
+
+namespace costmap_3d
+{
+
+class LayeredCostmap3D;
+
+/**
+ * Interface that layered costmaps use to access individual costmap layers.
+ * All costmap layers must extend this abstract class.
+ */
+class Layer3D
+{
+public:
+  Layer3D();
+  virtual ~Layer3D();
+
+  /** @brief Add nodes to bounds_map for any cells that have changed
+   *
+   * The point of updateBounds is to accumulate all the space that has
+   * changed in all layers since the last costmap update. For convenience, the
+   * changed space is represented as lethal occupied (even though all we are
+   * storing here is really a bit that means we should update this space).
+   * This layer should call updateNode(node, LETHAL) for every leaf
+   * node that has changed since the last update.
+   *
+   * Also, for rolling maps, layers should check for data that is outside the
+   * current rolled min/max that is passed in. For non-rolling maps, layers
+   * may assume the bounds only change when matchSize() is called.
+   * Note that layers do not need to put out-of-bounds cells into the
+   * bounds_map. The layered costmap will delete out-of-bounds cells from the
+   * master map and manage tracking their removal for publishing. It will not
+   * hurt anything to put the cells in the bounds map, it is just unnecessary.
+   */
+  virtual void updateBounds(const geometry_msgs::Pose robot_pose,
+                            const geometry_msgs::Point& rolled_min,
+                            const geometry_msgs::Point& rolled_max,
+                            Costmap3D* bounds_map) = 0;
+
+  /** @brief Copy the state of this costmap layer into the master layer using
+   * the bounds_map to limit what portion is copied.
+   *
+   * The point of updateCosts is to efficiently update the master layer
+   * using the update policy (update with max, or update with overwrite, or
+   * true overwrite).
+   */
+  virtual void updateCosts(const Costmap3D& bounds_map, Costmap3D* master_map) = 0;
+
+  /** @brief Initialize this layer. */
+  virtual void initialize(LayeredCostmap3D* parent, std::string name, tf::TransformListener *tf);
+
+  /** @brief Deactivate this layer. */
+  virtual void deactivate() = 0;
+
+  /** @brief Activate this layer. */
+  virtual void activate() = 0;
+
+  /** @brief Forget all memory as if restarting */
+  virtual void reset() = 0;
+
+  /** @brief Forget old sensor data within the given axis-aligned bounding box. */
+  virtual void resetBoundingBox(geometry_msgs::Point min_point, geometry_msgs::Point max_point) = 0;
+
+  /**
+   * @brief Check to make sure all the data in the layer is up to date.
+   *        If the layer is not up to date, then it may be unsafe to
+   *        plan using the data from this layer, and the planner may
+   *        need to know.
+   *
+   *        A layer's current state should be managed by the protected
+   *        variable current_.
+   * @return Whether the data in the layer is up to date.
+   */
+  virtual bool isCurrent() const;
+
+  /** @brief Called when the bounds or resolution changes.
+   *
+   * Note that in the case of any of these changes that the master costmap
+   * will always be reset and it will use a bounds map representing all space,
+   * so there is no need to attempt to attempt to track the bounds across a
+   * size change.
+   * Note also that unlike 2D costmaps, rolling 3D costmaps do not roll min
+   * and max. The OcTree stays at the original global origin, but the bounds
+   * are adjusted in updateMap to match the current robot pose. So for a
+   * rolling map, a plugin can delete any information outside the 2D limits of
+   * (max.x - min.x) / 2  or (max.y - min.y) / 2 from the robot pose, or it
+   * can independetly track the robot pose to efficiently only ray trace space
+   * inside the rolling window. For a non-rolling map, min and max represent
+   * the global frame limits (inclusive) for data allowed to be in the
+   * costmap.
+   * Note that the layered costmap will actively delete any out-of-bounds
+   * areas, so it is not possible to put things off the map.
+   */
+  virtual void matchSize(const geometry_msgs::Point& min, const geometry_msgs::Point& max, double resolution) = 0;
+
+  virtual std::string getName() const;
+
+  virtual void lock();
+
+  virtual void unlock();
+
+protected:
+  LayeredCostmap3D* layered_costmap_3d_;
+  bool current_;
+  std::string name_;
+  tf::TransformListener* tf_;
+  std::recursive_mutex mutex_;
+};
+
+}  // namespace costmap_3d
+
+#endif  // COSTMAP_3D_LAYER_3D_H_

--- a/costmap_3d/include/costmap_3d/layered_costmap_3d.h
+++ b/costmap_3d/include/costmap_3d/layered_costmap_3d.h
@@ -1,0 +1,208 @@
+/*********************************************************************
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Badger Technologies LLC
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: C. Andy Martin
+ *********************************************************************/
+#ifndef COSTMAP_3D_LAYERED_COSTMAP_3D_H_
+#define COSTMAP_3D_LAYERED_COSTMAP_3D_H_
+
+#include <vector>
+#include <string>
+#include <limits>
+#include <mutex>
+#include <map>
+#include <functional>
+#include <costmap_3d/layer_3d.h>
+#include <costmap_3d/costmap_3d.h>
+#include <costmap_2d/layered_costmap.h>
+#include <geometry_msgs/Point.h>
+
+namespace costmap_3d
+{
+
+class Layer3D;
+
+/**
+ * @class LayeredCostmap3D
+ * @brief Instantiates different 3D layer plugins and aggregates them into one 3D costmap
+ */
+class LayeredCostmap3D
+{
+public:
+  LayeredCostmap3D(const LayeredCostmap3D&) = delete;
+  LayeredCostmap3D& operator=(const LayeredCostmap3D&) = delete;
+  /**
+   * @brief Constructor for a 3D layered costmap
+   */
+  LayeredCostmap3D(costmap_2d::LayeredCostmap* layered_costmap_2d);
+
+  /**
+   * @brief Destructor
+   */
+  ~LayeredCostmap3D();
+
+  /**
+   * @brief Update the underlying costmap with new data.
+   */
+  void updateMap(geometry_msgs::Pose robot_pose);
+
+  /**
+   * @brief Get the number of times the costmap has been updated.
+   * Note: assumes lock is held (not using atomic ops or explicit barriers, so
+   * an old value could be returned w/out the lock held)
+   */
+  unsigned int getNumberOfUpdates() const {return num_updates_;}
+
+  std::string getGlobalFrameID() const {return layered_costmap_2d_->getGlobalFrameID();}
+  /**
+   * @brief Activate each layer (if deactivated).
+   */
+  void activate();
+
+  /**
+   * @brief Activate each layer (if deactivated).
+   */
+  void deactivate();
+
+  /**
+   * @brief Reset the entire costmap, deleting all state.
+   */
+  void reset();
+
+  bool isCurrent() const;
+
+  // The caller must be holding the lock to keep the costmap from updating on
+  // them. It is highly recommended to use RAII lock acquisition, such as
+  // std::lock_guard.
+  Costmap3DConstPtr getCostmap3D() const;
+
+  /** Returns if this costmap's x/y bounds are relative to the base
+   */
+  bool isRolling() const;
+
+  const std::vector<boost::shared_ptr<Layer3D>>& getPlugins();
+
+  void addPlugin(boost::shared_ptr<Layer3D> plugin);
+
+  // Lock the master costmap (used by planners to keep the costmap consistent
+  // while either planning, or copying the costmap to use for planning).
+  void lock();
+  void unlock();
+
+  double getResolution() const;
+
+  void getBounds(geometry_msgs::Point* min, geometry_msgs::Point* max);
+
+  /**
+   * @brief Set the Z bounds.
+   * The X/Y bounds come from the 2D layered costmap.
+   */
+  void setBounds(double min_z, double max_z);
+
+  // Pass the complete costmap, the delta map from the last update, and the
+  // bounds map on every completion.
+  using UpdateCompleteCallback = std::function<void(LayeredCostmap3D* layered_costmap_3d,
+                                                    const Costmap3D& delta_map,
+                                                    const Costmap3D& bounds_map)>;
+
+  /**
+   * @brief Register a callback to be called when a 3D costmap update is complete.
+   */
+  void registerUpdateCompleteCallback(const std::string callback_id, UpdateCompleteCallback cb);
+
+  /**
+   * @brief Unregister a callback to be called when a 3D costmap update is complete.
+   */
+  void unregisterUpdateCompleteCallback(const std::string callback_id);
+
+  /**
+   * @brief Get a pointer to the corresponding 2D layered costmap.
+   */
+  costmap_2d::LayeredCostmap* getLayeredCostmap2D() {return layered_costmap_2d_;}
+
+private:
+  // Check to see if our bounds match the 2D map, and change bounds if necessary.
+  // Check to see if our resolution matches the 2D map, and change it if necessary.
+  // Lock must be held while calling this internal function
+  void matchBoundsAndResolution();
+
+  // Update our Z bounds and also check to see if our bounds match the 2D map,
+  // and change bounds if necessary.
+  // Check to see if our resolution matches the 2D map, and change it if necessary.
+  // Lock must be held while calling this internal function
+  void matchBoundsAndResolution(double min_z, double max_z);
+
+  // Lock must be held while calling this internal function
+  void sizeChange();
+
+  class LockLayers
+  {
+  public:
+    LockLayers(LayeredCostmap3D* layered_costmap_3d);
+
+    // lock all layers preventing them from updating any state needed to be
+    // consistent between updateBounds and updateCosts
+    void lock();
+
+    // unlock all layers.
+    void unlock();
+  private:
+    LayeredCostmap3D* layered_costmap_3d_;
+  };
+
+  LockLayers lock_layers_;
+
+  // Master 3D cost map.
+  // Starts off NULL until our resolution is setup.
+  Costmap3DPtr costmap_;
+  std::recursive_mutex costmap_mutex_;
+
+  // Pointer to our sibling 2D costmap.
+  // We can use this to find our global frame.
+  // Also, we can use this pointer to keep the 2D costmap in sync with the 3D layers.
+  costmap_2d::LayeredCostmap* layered_costmap_2d_;
+
+  std::vector<boost::shared_ptr<Layer3D>> plugins_;
+  std::mutex update_complete_callbacks_mutex_;
+  std::map<std::string, UpdateCompleteCallback> update_complete_callbacks_;
+
+  bool size_changed_;
+  double resolution_;
+  geometry_msgs::Point min_point_, max_point_;
+  unsigned int num_updates_;
+};
+
+}  // namespace costmap_3d
+
+#endif  // COSTMAP_3D_LAYERED_COSTMAP_3D_H_

--- a/costmap_3d/include/costmap_3d/octomap_server_layer_3d.h
+++ b/costmap_3d/include/costmap_3d/octomap_server_layer_3d.h
@@ -1,0 +1,115 @@
+/*********************************************************************
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Badger Technologies LLC
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: C. Andy Martin
+ *********************************************************************/
+#ifndef COSTMAP_3D_OCTOMAP_SERVER_LAYER_3D_H_
+#define COSTMAP_3D_OCTOMAP_SERVER_LAYER_3D_H_
+
+#include <memory>
+#include <dynamic_reconfigure/server.h>
+#include <costmap_3d/GenericPluginConfig.h>
+#include <costmap_3d/costmap_layer_3d.h>
+#include <octomap_msgs/Octomap.h>
+#include <octomap_msgs/OctomapUpdate.h>
+
+namespace costmap_3d
+{
+
+class OctomapServerLayer3D : public CostmapLayer3D
+{
+  using super = CostmapLayer3D;
+public:
+  OctomapServerLayer3D();
+  virtual ~OctomapServerLayer3D();
+
+  virtual void initialize(LayeredCostmap3D* parent, std::string name, tf::TransformListener *tf);
+
+  virtual void updateBounds(const geometry_msgs::Pose robot_pose,
+                            const geometry_msgs::Point& rolled_min,
+                            const geometry_msgs::Point& rolled_max,
+                            Costmap3D* bounds_map);
+
+  /** @brief Deactivate this layer, unsubscribing.
+   */
+  virtual void deactivate();
+
+  /** @brief Activate this layer, subscribing. */
+  virtual void activate();
+
+  /** @brief Forward the reset to the octomap server as well. */
+  virtual void reset();
+
+  /** @brief Force a full transfer on resolution change. */
+  virtual void matchSize(const geometry_msgs::Point& min, const geometry_msgs::Point& max, double resolution);
+
+protected:
+  /** @brief Forward the bound box reset to the octomap server as well. */
+  virtual void resetBoundingBoxUnlocked(Costmap3DIndex min, Costmap3DIndex max);
+
+  virtual void mapCallback(const octomap_msgs::OctomapConstPtr& map_msg);
+  virtual void mapUpdateCallback(const octomap_msgs::OctomapUpdateConstPtr& map_update_msg);
+
+  virtual void mapUpdateInternal(const octomap_msgs::Octomap* map_msg,
+                                 const octomap_msgs::Octomap* bounds_msg);
+
+  virtual void reconfigureCallback(costmap_3d::GenericPluginConfig &config, uint32_t level);
+
+  virtual void subscribe();
+  virtual void unsubscribe();
+  virtual void subscribeUpdatesUnlocked();
+  virtual void unsubscribeUpdatesUnlocked();
+
+  ros::NodeHandle pnh_;
+  std::shared_ptr<dynamic_reconfigure::Server<costmap_3d::GenericPluginConfig>> dsrv_;
+  std::string map_topic_;
+  std::string map_update_topic_;
+  std::string reset_srv_name_;
+  std::string erase_bbx_srv_name_;
+  ros::ServiceClient reset_client_;
+  ros::ServiceClient erase_bbx_client_;
+  ros::Subscriber map_sub_;
+  ros::Subscriber map_update_sub_;
+  bool using_updates_;
+  bool active_;
+  bool first_full_map_update_received_;
+  size_t num_map_updates_;
+  uint32_t last_seq_;
+  ros::Duration data_valid_duration_;
+  ros::Time last_update_stamp_;
+};
+
+}  // namespace costmap_3d
+
+#endif  // COSTMAP_3D_OCTOMAP_SERVER_LAYER_3D_H_

--- a/costmap_3d/include/costmap_3d/point_cloud_layer_3d.h
+++ b/costmap_3d/include/costmap_3d/point_cloud_layer_3d.h
@@ -1,0 +1,107 @@
+/*********************************************************************
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Badger Technologies LLC
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: C. Andy Martin
+ *********************************************************************/
+#ifndef COSTMAP_3D_POINT_CLOUD_LAYER_3D_H_
+#define COSTMAP_3D_POINT_CLOUD_LAYER_3D_H_
+
+#include <memory>
+#include <dynamic_reconfigure/server.h>
+#include <costmap_3d/GenericPluginConfig.h>
+#include <costmap_3d/costmap_layer_3d.h>
+#include <tf2_ros/transform_listener.h>
+#include <pcl_ros/point_cloud.h>
+#include <pcl_conversions/pcl_conversions.h>
+#include <pcl/common/common.h>
+#include <pcl/common/transforms.h>
+#include <pcl/point_types.h>
+#include <pcl/point_cloud.h>
+
+namespace costmap_3d
+{
+
+class PointCloudLayer3D : public CostmapLayer3D
+{
+  using super = CostmapLayer3D;
+  using PointCloud = pcl::PointCloud<pcl::PointXYZ>;
+  using PointCloudWithIntensity = pcl::PointCloud<pcl::PointXYZI>;
+public:
+  PointCloudLayer3D();
+  virtual ~PointCloudLayer3D();
+
+  virtual void initialize(LayeredCostmap3D* parent, std::string name, tf::TransformListener *tf);
+
+  virtual void updateBounds(const geometry_msgs::Pose robot_pose,
+                            const geometry_msgs::Point& rolled_min,
+                            const geometry_msgs::Point& rolled_max,
+                            Costmap3D* bounds_map);
+
+  /** @brief Deactivate this layer, unsubscribing.
+   */
+  virtual void deactivate();
+
+  /** @brief Activate this layer, subscribing. */
+  virtual void activate();
+
+protected:
+  template <typename PointType>
+  Cost pointIntensityToCost(PointType point);
+
+  template <typename CloudType>
+  void pointCloudCallback(const typename CloudType::ConstPtr& cloud_msg);
+
+  virtual void reconfigureCallback(costmap_3d::GenericPluginConfig &config, uint32_t level);
+
+  virtual void subscribe();
+  virtual void unsubscribe();
+
+  ros::NodeHandle pnh_;
+  std::shared_ptr<dynamic_reconfigure::Server<costmap_3d::GenericPluginConfig>> dsrv_;
+  bool active_;
+  std::string cloud_topic_;
+  ros::Subscriber cloud_sub_;
+  bool cloud_has_intensity_;
+  // Intensity values at or below free_intensity_ are considred free.
+  // Intensity values at or above lethal_intensity_ value are considered lethal.
+  // Intensity values between free_intensity_ and lethal_intesnity_ are linearly interpolated.
+  float free_intensity_;
+  float lethal_intensity_;
+  ros::Duration data_valid_duration_;
+  ros::Time last_update_stamp_;
+};
+
+}  // namespace costmap_3d
+
+#endif  // COSTMAP_3D_POINT_CLOUD_LAYER_3D_H_

--- a/costmap_3d/launch/example.launch
+++ b/costmap_3d/launch/example.launch
@@ -1,0 +1,12 @@
+<launch>
+  <!--
+  NOTE: You'll need to bring up an octomap server to publish the octomap data
+  and rviz to visualize the results.
+
+  Also, if running from bagfiles, set the "use_sim_time" parameter to true
+  -->
+  <node name="costmap_3d_node" pkg="costmap_3d" type="costmap_3d_node" output="screen">
+    <rosparam file="$(find costmap_3d)/launch/example_params.yaml" command="load" ns="costmap" />
+  </node>
+
+</launch>

--- a/costmap_3d/launch/example_params.yaml
+++ b/costmap_3d/launch/example_params.yaml
@@ -1,0 +1,39 @@
+global_frame: odom
+robot_base_frame: base_footprint
+rolling_window: true
+track_unknown_space: true
+always_send_full_costmap: false
+
+publish_frequency: 5.0
+update_frequency: 5.0
+transform_tolerance: 1.5
+
+resolution: 0.05
+width: 8
+height: 8
+origin_x: 0.0
+origin_y: 0.0
+max_obstacle_height: 2.05
+
+footprint: [[-0.325, -0.325], [-0.325, 0.325], [0.325, 0.325], [0.46, 0.0], [0.325, -0.325]]
+footprint_padding: 0.01
+
+costmap_3d:
+  plugins:
+  - {name: costmap_3d_to_2d, type: 'costmap_3d::Costmap3DTo2DLayer3D'}
+  - {name: occupancy_octomap_layer, type: 'costmap_3d::OctomapServerLayer3D'}
+  occupancy_octomap_layer:
+    octomap_server_namespace: '/'
+    octomap_server_node_name: occupancy_octomap
+    enabled: true
+    # Combine with maximum (1, see cfg/GenericPlugin.cfg for all values)
+    combination_method: 1
+
+plugins:
+- {name: costmap_3d_to_2d, type: 'costmap_3d::Costmap3DTo2DLayer'}
+
+costmap_3d_to_2d:
+  enabled: true
+  # Combine with maximum (1, see cfg/GenericPlugin.cfg for all values)
+  combination_method: 1
+

--- a/costmap_3d/package.xml
+++ b/costmap_3d/package.xml
@@ -1,0 +1,42 @@
+<package format="2">
+  <name>costmap_3d</name>
+  <version>0.1.0</version>
+  <description>
+    This package provides an implementation of a 3D costmap. The ROS 3D costmap
+    is a specialization of the ROS 2D costmap interface for backwards
+    compatability with existing navigation code. Additionally, it provides
+    a new interface to find the cost of a stored robot mesh at a given pose
+    using a MoveIt! planning scene. Also, the 3D costmap
+    contains some standard 3D costmap plugins. The octomap_server plugin
+    wraps an OctomapServer object as a 3D costmap layer. The OctomapServer
+    is capable of serving static octomaps and/or build up sensor data into an
+    octomap. This allows multiple layers of sensor data that does not
+    cross-clear. The costmap_3d_to_2d_layer plugin forwards the 3D costmap
+    data to the 2D costmap.
+  </description>
+  <author>C. Andy Martin</author>
+  <maintainer email="cam@badger-technologies.com">C. Andy Martin</maintainer>
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>message_generation</build_depend>
+  <exec_depend>message_runtime</exec_depend>
+  <depend>costmap_2d</depend>
+  <depend>tf_conversions</depend>
+  <depend>dynamic_reconfigure</depend>
+  <depend>actionlib_msgs</depend>
+  <depend>pluginlib</depend>
+  <depend>roscpp</depend>
+  <depend>geometry_msgs</depend>
+  <depend>octomap</depend>
+  <depend>octomap_msgs</depend>
+  <depend>pcl_ros</depend>
+  <depend>pcl_msgs</depend>
+  <depend>pcl_conversions</depend>
+  <depend>fcl</depend>
+  <export>
+    <costmap_2d plugin="${prefix}/costmap_2d_plugins.xml"/>
+    <costmap_3d plugin="${prefix}/costmap_3d_plugins.xml"/>
+  </export>
+</package>

--- a/costmap_3d/plugins/costmap_3d_to_2d_layer.cpp
+++ b/costmap_3d/plugins/costmap_3d_to_2d_layer.cpp
@@ -1,0 +1,263 @@
+/*********************************************************************
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Badger Technologies LLC
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: C. Andy Martin
+ *********************************************************************/
+#include <costmap_3d/costmap_3d_to_2d_layer.h>
+#include <costmap_2d/cost_values.h>
+#include <costmap_3d/GenericPluginConfig.h>
+#include <costmap_3d/costmap_3d.h>
+#include <pluginlib/class_list_macros.h>
+
+PLUGINLIB_EXPORT_CLASS(costmap_3d::Costmap3DTo2DLayer, costmap_2d::Layer)
+
+namespace costmap_3d
+{
+
+Costmap3DTo2DLayer::Costmap3DTo2DLayer()
+    : copy_full_map_(true)
+{
+}
+
+Costmap3DTo2DLayer::~Costmap3DTo2DLayer()
+{
+}
+
+void Costmap3DTo2DLayer::onInitialize()
+{
+  ros::NodeHandle nh("~/" + name_);
+
+  default_value_ = costmap_2d::NO_INFORMATION;
+
+  reset();
+
+  dsrv_.reset(new dynamic_reconfigure::Server<costmap_3d::GenericPluginConfig>(nh));
+  dsrv_->setCallback(std::bind(&Costmap3DTo2DLayer::reconfigureCB, this,
+                               std::placeholders::_1, std::placeholders::_2));
+}
+
+void Costmap3DTo2DLayer::reconfigureCB(costmap_3d::GenericPluginConfig &config, uint32_t level)
+{
+  enabled_ = config.enabled;
+  switch (config.combination_method)
+  {
+    case GenericPlugin_Maximum:
+      use_maximum_ = true;
+      break;
+    case GenericPlugin_Overwrite:
+      use_maximum_ = false;
+      break;
+    default:
+    case GenericPlugin_Nothing:
+      config.enabled = false;
+      enabled_ = false;
+      break;
+  }
+}
+
+void Costmap3DTo2DLayer::matchSize()
+{
+  copy_full_map_ = true;
+  super::matchSize();
+  addExtraBounds(getOriginX(), getOriginY(), getSizeInMetersX(), getSizeInMetersY());
+}
+
+void Costmap3DTo2DLayer::activate()
+{
+}
+
+void Costmap3DTo2DLayer::deactivate()
+{
+  reset();
+}
+
+void Costmap3DTo2DLayer::reset()
+{
+  super::resetMaps();
+  current_ = false;
+  layered_costmap_3d_ = NULL;
+  copy_full_map_ = true;
+  addExtraBounds(getOriginX(), getOriginY(), getSizeInMetersX(), getSizeInMetersY());
+}
+
+void Costmap3DTo2DLayer::updateBounds(double robot_x, double robot_y, double robot_yaw, double* min_x, double* min_y,
+                               double* max_x, double* max_y)
+{
+  if (layered_costmap_->isRolling())
+  {
+    costmap_2d::Costmap2D* master = layered_costmap_->getCostmap();
+    if (getOriginX() != master->getOriginX() || getOriginY() != master->getOriginY())
+    {
+      updateOrigin(robot_x - getSizeInMetersX() / 2, robot_y - getSizeInMetersY() / 2);
+      // We could attempt to see if we only shifted in X or Y and minimize the
+      // impact on bounds. However, prefer the simplicity of just updating
+      // everything on a shift.
+      addExtraBounds(getOriginX(), getOriginY(), getSizeInMetersX(), getSizeInMetersY());
+    }
+  }
+  if (enabled_ && layered_costmap_3d_)
+  {
+    int min_map_x, min_map_y;
+    int max_map_x, max_map_y;
+    {
+      // First erase the bounding-box of the 2D map.
+      worldToMapEnforceBounds(extra_min_x_, extra_min_y_, min_map_x, min_map_y);
+      worldToMapEnforceBounds(extra_max_x_, extra_max_y_, max_map_x, max_map_y);
+      assert(min_map_x >= 0);
+      assert(min_map_x < (signed)size_x_);
+      assert(min_map_y >= 0);
+      assert(min_map_y < (signed)size_y_);
+      assert(max_map_x >= 0);
+      assert(max_map_x < (signed)size_x_);
+      assert(max_map_y >= 0);
+      assert(max_map_y < (signed)size_y_);
+      for (int row = min_map_y; row <= max_map_y; ++row)
+      {
+        const int row_len = (max_map_x - min_map_x) + 1;
+        const int row_step = size_x_;
+        memset(costmap_ + min_map_x + row * row_step, default_value_, row_len);
+      }
+    }
+
+    {
+      // The updateMap method locks the master costmap, locking both the 2D
+      // and 3D costmaps (since they use the same lock). Therefore, the 3D
+      // costmap can not change, and trying to lock here would cause a deadlock.
+
+      // Update the regions that have changed
+      // Create a bound-box iterator over the 3D costmap.
+      Costmap3DConstPtr master_3d = layered_costmap_3d_->getCostmap3D();
+      Costmap3DIndex min_index, max_index;
+      master_3d->coordToKeyClamped(extra_min_x_, extra_min_y_, -std::numeric_limits<double>::max(),
+                                   min_index);
+      master_3d->coordToKeyClamped(extra_max_x_, extra_max_y_, std::numeric_limits<double>::max(),
+                                   max_index);
+      auto it = master_3d->begin_leafs_bbx(min_index, max_index);
+      auto end = master_3d->end_leafs_bbx();
+
+      assert(resolution_ > 0.0);
+      assert((master_3d->getResolution() - resolution_) < 1e-6);
+      const int map_ox = (int)std::round(origin_x_ / resolution_);
+      const int map_oy = (int)std::round(origin_y_ / resolution_);
+      const int map_3d_ox = (1 << (master_3d->getTreeDepth() - 1));
+      const int map_3d_oy = (1 << (master_3d->getTreeDepth() - 1));
+
+      while (it != end)
+      {
+        Costmap3DIndex min_index_3d = it.getIndexKey();
+        const int min_x_3d = (int)min_index_3d[0] - map_3d_ox;
+        const int min_y_3d = (int)min_index_3d[1] - map_3d_oy;
+        const octomap::key_type depth_diff_3d = master_3d->getTreeDepth() - it.getDepth();
+        const octomap::key_type size_3d = (((octomap::key_type)1u)<<depth_diff_3d) - 1u;
+        const int max_x_3d = min_x_3d + size_3d;
+        const int max_y_3d = min_y_3d + size_3d;
+        const unsigned char cost = toCostmap2D(it->getValue());
+
+        for (int y = min_y_3d; y <= max_y_3d; ++y)
+        {
+          for (int x = min_x_3d; x <= max_x_3d; ++x)
+          {
+            const int map_x = x - map_ox;
+            const int map_y = y - map_oy;
+            if (map_x >= min_map_x && map_y >= min_map_y && map_x <= max_map_x && map_y <= max_map_y)
+            {
+              const unsigned int map_index = getIndex(map_x, map_y);
+              if (costmap_[map_index] == costmap_2d::NO_INFORMATION || cost > costmap_[map_index])
+              {
+                costmap_[map_index] = cost;
+              }
+            }
+          }
+        }
+        ++it;
+      }
+    }
+    useExtraBounds(min_x, min_y, max_x, max_y);
+  }
+}
+
+void Costmap3DTo2DLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, int min_j, int max_i, int max_j)
+{
+  if (!use_maximum_)
+    updateWithOverwrite(master_grid, min_i, min_j, max_i, max_j);
+  else
+    updateWithMax(master_grid, min_i, min_j, max_i, max_j);
+}
+
+void Costmap3DTo2DLayer::updateFrom3D(LayeredCostmap3D* layered_costmap_3d, const Costmap3D& delta, const Costmap3D& bounds_map)
+{
+  // cache a pointer to the 3d layered costmap to use later
+  layered_costmap_3d_ = layered_costmap_3d;
+
+  // Note: this function is only ever called during the costmap update
+  // process, so we do not need to worry about synchronization w/ the layered
+  // costmap.
+  current_ = true;
+
+  // Get our extra bounds added for this update.
+  Costmap3D::iterator it, end;
+  if (copy_full_map_)
+  {
+    it = layered_costmap_3d_->getCostmap3D()->begin_leafs();
+    end = layered_costmap_3d_->getCostmap3D()->end_leafs();
+    copy_full_map_ = false;
+  }
+  else
+  {
+    it = bounds_map.begin_leafs();
+    end = bounds_map.end_leafs();
+  }
+
+  while (it != end)
+  {
+    double half_size = it.getSize() / 2.0;
+    double x = it.getX();
+    double y = it.getY();
+    addExtraBounds(x - half_size, y - half_size, x + half_size, y + half_size);
+    ++it;
+  }
+}
+
+unsigned char Costmap3DTo2DLayer::toCostmap2D(Cost value) const
+{
+  if (value >= LETHAL) return costmap_2d::LETHAL_OBSTACLE;
+  if (value == FREE) return costmap_2d::FREE_SPACE;
+  if (value < FREE) return costmap_2d::NO_INFORMATION;
+
+  // return a linear interpolation of 3D Cost values to 2D cost values
+  return static_cast<uint8_t>((costmap_2d::LETHAL_OBSTACLE - costmap_2d::FREE_SPACE) *
+                              (value - FREE) / (LETHAL - FREE)) + costmap_2d::FREE_SPACE;
+}
+
+}  // namespace costmap_2d

--- a/costmap_3d/plugins/costmap_3d_to_2d_layer_3d.cpp
+++ b/costmap_3d/plugins/costmap_3d_to_2d_layer_3d.cpp
@@ -1,0 +1,99 @@
+/*********************************************************************
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Badger Technologies LLC
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: C. Andy Martin
+ *********************************************************************/
+#include <costmap_3d/costmap_3d_to_2d_layer_3d.h>
+#include <costmap_3d/costmap_3d_to_2d_layer.h>
+#include <pluginlib/class_list_macros.h>
+
+PLUGINLIB_EXPORT_CLASS(costmap_3d::Costmap3DTo2DLayer3D, costmap_3d::Layer3D)
+
+namespace costmap_3d
+{
+
+Costmap3DTo2DLayer3D::Costmap3DTo2DLayer3D()
+{
+  // This layer is always current
+  current_ = true;
+}
+
+Costmap3DTo2DLayer3D::~Costmap3DTo2DLayer3D()
+{
+  deactivate();
+}
+
+void Costmap3DTo2DLayer3D::initialize(LayeredCostmap3D* parent, std::string name, tf::TransformListener *tf)
+{
+  super::initialize(parent, name, tf);
+  activate();
+}
+
+void Costmap3DTo2DLayer3D::activate()
+{
+  // Find any costmap 3D to 2D layers and connect them to the 3D costmap
+  costmap_2d::LayeredCostmap* layered_costmap_2d = layered_costmap_3d_->getLayeredCostmap2D();
+  costmap_3d::Costmap3DTo2DLayer* layer_2d;
+  for (auto plugin_2d : *layered_costmap_2d->getPlugins())
+  {
+    layer_2d = dynamic_cast<costmap_3d::Costmap3DTo2DLayer*>(plugin_2d.get());
+    if (layer_2d != nullptr)
+    {
+      layered_costmap_3d_->registerUpdateCompleteCallback(
+          layer_2d->getName(),
+          std::bind(&Costmap3DTo2DLayer::updateFrom3D,
+                    layer_2d,
+                    std::placeholders::_1,
+                    std::placeholders::_2,
+                    std::placeholders::_3));
+    }
+  }
+}
+
+void Costmap3DTo2DLayer3D::deactivate()
+{
+  // Find any costmap 3D to 2D layers and disconnect them from the 3D costmap
+  costmap_2d::LayeredCostmap* layered_costmap_2d = layered_costmap_3d_->getLayeredCostmap2D();
+  costmap_3d::Costmap3DTo2DLayer* layer_2d;
+  for (auto plugin_2d : *layered_costmap_2d->getPlugins())
+  {
+    layer_2d = dynamic_cast<costmap_3d::Costmap3DTo2DLayer*>(plugin_2d.get());
+    if (layer_2d != nullptr)
+    {
+      layered_costmap_3d_->unregisterUpdateCompleteCallback(layer_2d->getName());
+    }
+  }
+}
+
+}  // namespace costmap_3d

--- a/costmap_3d/plugins/octomap_server_layer_3d.cpp
+++ b/costmap_3d/plugins/octomap_server_layer_3d.cpp
@@ -1,0 +1,420 @@
+/*********************************************************************
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Badger Technologies LLC
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: C. Andy Martin
+ *********************************************************************/
+#include <costmap_3d/octomap_server_layer_3d.h>
+#include <std_srvs/Empty.h>
+#include <octomap_msgs/BoundingBoxQuery.h>
+#include <octomap_msgs/conversions.h>
+#include <pluginlib/class_list_macros.h>
+
+PLUGINLIB_EXPORT_CLASS(costmap_3d::OctomapServerLayer3D, costmap_3d::Layer3D)
+
+namespace costmap_3d
+{
+
+OctomapServerLayer3D::OctomapServerLayer3D() : super(), using_updates_(false)
+{
+  current_ = false;
+}
+
+OctomapServerLayer3D::~OctomapServerLayer3D()
+{
+}
+
+void OctomapServerLayer3D::initialize(LayeredCostmap3D* parent, std::string name, tf::TransformListener *tf)
+{
+  super::initialize(parent, name, tf);
+  // Note that the master costmap's resolution is not set yet.
+  // Our setResolution method will be called later once it is set.
+
+  // Get names of topics and servers from parameter server
+  pnh_ = ros::NodeHandle("~/" + name);
+
+  std::string octomap_server_ns = pnh_.param("octomap_server_namespace", std::string(""));
+  std::string octomap_server_name = pnh_.param("octomap_server_node_name", std::string("octomap_server"));
+  std::string topic_prefix = octomap_server_ns;
+  if (octomap_server_ns.size() > 0 && octomap_server_ns.rbegin()[0] != '/')
+  {
+    topic_prefix = octomap_server_ns + "/";
+  }
+  std::string srv_prefix = topic_prefix + octomap_server_name + "/";
+
+  reset_srv_name_ = srv_prefix + "reset";
+  erase_bbx_srv_name_ = srv_prefix + "erase_bbx";
+  map_topic_ = pnh_.param("map_topic", topic_prefix + "octomap_binary");
+  map_update_topic_ = pnh_.param("map_update_topic", map_topic_ + "_updates");
+  double data_valid_duration = pnh_.param("data_valid_duration", 0.0);
+  data_valid_duration_ = ros::Duration(data_valid_duration);
+
+  ROS_INFO_STREAM("OctomapServerLayer3D " << name << ": initializing");
+  ROS_INFO_STREAM("  map_topic: " << map_topic_);
+  ROS_INFO_STREAM("  map_update_topic: " << map_update_topic_);
+  ROS_INFO_STREAM("  reset_srv_name: " << reset_srv_name_);
+  ROS_INFO_STREAM("  erase_bbx_srv_name: " << erase_bbx_srv_name_);
+  if (data_valid_duration > 0.0)
+    ROS_INFO_STREAM("  data_valid_duration: " << data_valid_duration);
+
+  dsrv_.reset(new dynamic_reconfigure::Server<costmap_3d::GenericPluginConfig>(pnh_));
+  dsrv_->setCallback(std::bind(&OctomapServerLayer3D::reconfigureCallback, this,
+                               std::placeholders::_1, std::placeholders::_2));
+
+  activate();
+}
+
+void OctomapServerLayer3D::reconfigureCallback(costmap_3d::GenericPluginConfig &config, uint32_t level)
+{
+  std::lock_guard<Layer3D> lock(*this);
+  if (enabled_ && !config.enabled)
+  {
+    if (costmap_) touch(*costmap_);
+    // disable last, so touch does something
+    enabled_ = false;
+  }
+  else if (!enabled_ && config.enabled)
+  {
+    // enable first, so touch does something
+    enabled_ = true;
+    if (costmap_) touch(*costmap_);
+  }
+  combination_method_ = config.combination_method;
+}
+
+void OctomapServerLayer3D::updateBounds(
+    const geometry_msgs::Pose robot_pose,
+    const geometry_msgs::Point& rolled_min,
+    const geometry_msgs::Point& rolled_max,
+    Costmap3D* bounds_map)
+{
+  std::lock_guard<Layer3D> lock(*this);
+  bool current = true;
+  if (data_valid_duration_ > ros::Duration(0.0))
+  {
+    if (ros::Time::now() - last_update_stamp_ > data_valid_duration_)
+    {
+      ROS_WARN_STREAM_THROTTLE(1.0, "Layer " << name_ << " octomap not updated for "
+                               << (ros::Time::now() - last_update_stamp_).toSec()
+                               << " expected update in at least " <<  data_valid_duration_.toSec());
+      current = false;
+    }
+  }
+  current_ = current;
+  super::updateBounds(robot_pose, rolled_min, rolled_max, bounds_map);
+}
+
+void OctomapServerLayer3D::deactivate()
+{
+  std::lock_guard<Layer3D> lock(*this);
+  active_ = false;
+  unsubscribe();
+  super::deactivate();
+  reset_client_.shutdown();
+  erase_bbx_client_.shutdown();
+}
+
+void OctomapServerLayer3D::activate()
+{
+  ros::ServiceClient reset_client = pnh_.serviceClient<std_srvs::Empty>(reset_srv_name_);
+  ros::ServiceClient erase_bbx_client = pnh_.serviceClient<octomap_msgs::BoundingBoxQuery>(erase_bbx_srv_name_);
+
+  // Wait a while for the servers to exist, but not too long.
+  // We will handle them not existing below.
+  if (!reset_client.waitForExistence(ros::Duration(10.0)))
+  {
+    ROS_WARN_STREAM("OctomapServerLayer3D " << name_ << ": Failed to wait for service " << reset_srv_name_);
+  }
+  if (!erase_bbx_client.waitForExistence(ros::Duration(10.0)))
+  {
+    ROS_WARN_STREAM("OctomapServerLayer3D " << name_ << ": Failed to wait for service " << erase_bbx_srv_name_);
+  }
+
+  std::lock_guard<Layer3D> lock(*this);
+  reset_client_ = reset_client;
+  erase_bbx_client_ = erase_bbx_client;
+  super::activate();
+  subscribe();
+  active_ = true;
+}
+
+void OctomapServerLayer3D::subscribe()
+{
+  std::lock_guard<Layer3D> lock(*this);
+  map_sub_ = pnh_.subscribe<octomap_msgs::Octomap>(map_topic_, 1, std::bind(&OctomapServerLayer3D::mapCallback,
+                                                                            this, std::placeholders::_1));
+  subscribeUpdatesUnlocked();
+}
+
+void OctomapServerLayer3D::subscribeUpdatesUnlocked()
+{
+  first_full_map_update_received_ = false;
+  num_map_updates_ = 0;
+  map_update_sub_ = pnh_.subscribe<octomap_msgs::OctomapUpdate>(map_update_topic_, 10,
+                                                                std::bind(&OctomapServerLayer3D::mapUpdateCallback,
+                                                                          this, std::placeholders::_1));
+}
+
+void OctomapServerLayer3D::unsubscribe()
+{
+  std::lock_guard<Layer3D> lock(*this);
+  map_sub_.shutdown();
+  using_updates_ = false;
+  unsubscribeUpdatesUnlocked();
+}
+
+void OctomapServerLayer3D::unsubscribeUpdatesUnlocked()
+{
+  map_update_sub_.shutdown();
+}
+
+void OctomapServerLayer3D::reset()
+{
+  std::lock_guard<Layer3D> lock(*this);
+
+  super::reset();
+
+  // reset octomap server
+  if (reset_client_.exists())
+  {
+    std_srvs::Empty srv;
+    reset_client_.call(srv);
+  }
+  else
+  {
+    ROS_WARN_STREAM_THROTTLE(1.0, "OctomapServerLayer3D " << name_ <<
+                             ": Unable to call octomap server's reset service");
+  }
+
+  // Keep the layer non-current until the first map update cycle after the
+  // first data message is received to keep from driving blind.
+  current_ = false;
+  last_update_stamp_ = ros::Time(0.0);
+}
+
+void OctomapServerLayer3D::resetBoundingBoxUnlocked(Costmap3DIndex min, Costmap3DIndex max)
+{
+  super::resetBoundingBoxUnlocked(min, max);
+
+  if (erase_bbx_client_.exists())
+  {
+    octomap_msgs::BoundingBoxQuery srv;
+    srv.request.min = fromOctomapPoint(costmap_->keyToCoord(min));
+    srv.request.max = fromOctomapPoint(costmap_->keyToCoord(max));
+    erase_bbx_client_.call(srv);
+  }
+  else
+  {
+    ROS_WARN_STREAM_THROTTLE(1.0, "OctomapServerLayer3D " << name_ <<
+                             ": Unable to call octomap server's erase_bbx service");
+  }
+
+  // Keep the layer non-current until the first map update cycle after the
+  // first data message is received to keep from driving blind.
+  current_ = false;
+  last_update_stamp_ = ros::Time(0.0);
+};
+
+void OctomapServerLayer3D::matchSize(const geometry_msgs::Point& min, const geometry_msgs::Point& max, double resolution)
+{
+  if (!costmap_ || resolution != costmap_->getResolution())
+  {
+    // Resolution will change, need to request full message.
+    // Do this by re-subscribing to the map topics.
+    unsubscribe();
+    subscribe();
+  }
+  super::matchSize(min, max, resolution);
+
+  // If octomap server ever exposes its limits via dynamic reconfigure, we
+  // could set them here.
+}
+
+void OctomapServerLayer3D::mapCallback(const octomap_msgs::OctomapConstPtr& map_msg)
+{
+  std::lock_guard<Layer3D> lock(*this);
+  if (active_ && !using_updates_)
+    mapUpdateInternal(map_msg.get(), nullptr);
+}
+
+void OctomapServerLayer3D::mapUpdateCallback(const octomap_msgs::OctomapUpdateConstPtr& map_update_msg)
+{
+  std::lock_guard<Layer3D> lock(*this);
+  if (!active_)
+  {
+    // We have been deactivated, but there was still an outstanding message
+    // callback. Throw this message away.
+    return;
+  }
+  num_map_updates_++;
+  if (!first_full_map_update_received_)
+  {
+    // Check if this the full map published by the connect callback.
+    // That map is signaled by having the octomap_bounds seq be different
+    // from the octomap_update seq.
+    // Ignore the first normal published update until the first full map
+    // is received.
+    if (num_map_updates_ == 1 &&
+        map_update_msg->octomap_bounds.header.seq == map_update_msg->octomap_update.header.seq)
+    {
+      // Ignore the first normal update until the first full map is received.
+      // There is a race where this may happen, and we must simply ignore the
+      // first.
+      return;
+    }
+    else if(num_map_updates_ > 1)
+    {
+      // Huh. We never got the first full map, this means we lost that
+      // message. We have no choice but to re-subscribe.
+      ROS_WARN("Lost first full map update message, resubscribing.");
+      unsubscribeUpdatesUnlocked();
+      subscribeUpdatesUnlocked();
+      return;
+    }
+    first_full_map_update_received_ = true;
+  }
+  else
+  {
+    if (last_seq_ + 1 < map_update_msg->octomap_bounds.header.seq)
+    {
+      ROS_WARN("Lost an update message, resubscribing to get entire map.");
+      ROS_INFO_STREAM("Expected sequence number " << last_seq_ + 1 << " but received "
+                      << map_update_msg->octomap_bounds.header.seq);
+      unsubscribeUpdatesUnlocked();
+      subscribeUpdatesUnlocked();
+      return;
+    }
+    else if(last_seq_ + 1 > map_update_msg->octomap_bounds.header.seq)
+    {
+      // We have moved backwards. This means either the server restarted, or
+      // we are running from a bagfile and it was rewound. In either case,
+      // the message should already have a universal bounds, so there is
+      // nothing to do, as it will reset our memory for us.
+    }
+  }
+  last_seq_ = map_update_msg->octomap_bounds.header.seq;
+
+  if (!using_updates_)
+  {
+    using_updates_ = true;
+    // now that we are using updates, there is no need for the map sub
+    map_sub_.shutdown();
+  }
+  mapUpdateInternal(&map_update_msg->octomap_update, &map_update_msg->octomap_bounds);
+}
+
+void OctomapServerLayer3D::mapUpdateInternal(const octomap_msgs::Octomap* map_msg,
+                                             const octomap_msgs::Octomap* bounds_msg)
+{
+  if (!changed_cells_ || !costmap_)
+  {
+    // No costmap to update yet
+    ROS_WARN_STREAM_THROTTLE(1.0, "OctomapServerLayer3D " << name_ << ": received update before costmap was setup, ignoring");
+    return;
+  }
+
+  // Verify binary, resolution and frame match.
+  if (!map_msg->binary)
+  {
+    ROS_WARN_STREAM_THROTTLE(1.0, "OctomapServerLayer3D " << name_ << ": received non-binary map, ignoring");
+  }
+  else if (bounds_msg != nullptr && !bounds_msg->binary)
+  {
+    ROS_WARN_STREAM_THROTTLE(1.0, "OctomapServerLayer3D " << name_ << ": received non-binary bounds map, ignoring");
+  }
+  else if(std::abs(map_msg->resolution - costmap_->getResolution()) > 1e-6)
+  {
+    ROS_WARN_STREAM_THROTTLE(1.0, "OctomapServerLayer3D " << name_ << ": received map with resolution " <<
+                             map_msg->resolution << " but costmap resolution is " <<
+                             costmap_->getResolution() << ", ignoring");
+  }
+  else if(bounds_msg != nullptr && std::abs(bounds_msg->resolution - costmap_->getResolution()) > 1e-6)
+  {
+    ROS_WARN_STREAM_THROTTLE(1.0, "OctomapServerLayer3D " << name_ << ": received bounds map with resolution " <<
+                             map_msg->resolution << " but costmap resolution is " <<
+                             costmap_->getResolution() << ", ignoring");
+  }
+  else if(map_msg->header.frame_id != layered_costmap_3d_->getGlobalFrameID())
+  {
+    ROS_WARN_STREAM_THROTTLE(1.0, "OctomapServerLayer3D " << name_ << ": received map in frame " <<
+                             map_msg->header.frame_id << " but global frame is " <<
+                             layered_costmap_3d_->getGlobalFrameID() << ", ignoring");
+  }
+  else if(bounds_msg != nullptr && bounds_msg->header.frame_id != layered_costmap_3d_->getGlobalFrameID())
+  {
+    ROS_WARN_STREAM_THROTTLE(1.0, "OctomapServerLayer3D " << name_ << ": received bounds map in frame " <<
+                             bounds_msg->header.frame_id << " but global frame is " <<
+                             layered_costmap_3d_->getGlobalFrameID() << ", ignoring");
+  }
+  else
+  {
+    std::shared_ptr<octomap::AbstractOcTree> abstract_map(octomap_msgs::binaryMsgToMap(*map_msg));
+    octomap::OcTree* map = dynamic_cast<octomap::OcTree*>(abstract_map.get());
+    if (map == nullptr)
+    {
+      ROS_WARN_STREAM_THROTTLE(1.0, "OctomapServerLayer3D " << name_ << ": unable to dynamic cast received tree");
+    }
+    else
+    {
+      ROS_DEBUG_STREAM("received value octomap with size " << map->size());
+      last_update_stamp_ = map_msg->header.stamp;
+      std::shared_ptr<octomap::AbstractOcTree> abstract_bounds_map;
+      if (bounds_msg != nullptr)
+      {
+        abstract_bounds_map.reset(octomap_msgs::binaryMsgToMap(*bounds_msg));
+      }
+      else
+      {
+        // If no bounds are given, use the whole universe
+        Costmap3D* universe_bounds_map = new Costmap3D(costmap_->getResolution());
+        universe_bounds_map->setNodeValueAtDepth(Costmap3DIndex(), 0, LETHAL);
+        abstract_bounds_map.reset(universe_bounds_map);
+      }
+      octomap::OcTree* bounds_map = dynamic_cast<octomap::OcTree*>(abstract_bounds_map.get());
+      if (bounds_map == nullptr)
+      {
+        ROS_WARN_STREAM_THROTTLE(1.0, "OctomapServerLayer3D " << name_ << ": unable to dynamic cast received bounds");
+      }
+      else
+      {
+        ROS_DEBUG_STREAM("using bounds octomap with size " << bounds_map->size());
+        // Use zero log odds as the threshold for any incoming binary map
+        updateCells(*map, *bounds_map, 0.0);
+        ROS_DEBUG_STREAM("after update cells, costmap_ has size " << costmap_->size());
+        ROS_DEBUG_STREAM(" and changed_cells_ has size " << changed_cells_->size());
+      }
+    }
+  }
+}
+
+}  // namespace costmap_3d

--- a/costmap_3d/plugins/point_cloud_layer_3d.cpp
+++ b/costmap_3d/plugins/point_cloud_layer_3d.cpp
@@ -1,0 +1,245 @@
+/*********************************************************************
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Badger Technologies LLC
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: C. Andy Martin
+ *********************************************************************/
+#include <costmap_3d/point_cloud_layer_3d.h>
+#include <pluginlib/class_list_macros.h>
+#include <tf_conversions/tf_eigen.h>
+
+PLUGINLIB_EXPORT_CLASS(costmap_3d::PointCloudLayer3D, costmap_3d::Layer3D)
+
+namespace costmap_3d
+{
+
+PointCloudLayer3D::PointCloudLayer3D() : super()
+{
+  current_ = false;
+}
+
+PointCloudLayer3D::~PointCloudLayer3D()
+{
+}
+
+void PointCloudLayer3D::initialize(LayeredCostmap3D* parent, std::string name, tf::TransformListener *tf)
+{
+  super::initialize(parent, name, tf);
+
+  // Get names of topics and servers from parameter server
+  pnh_ = ros::NodeHandle("~/" + name);
+
+  cloud_topic_ = pnh_.param("cloud_topic", std::string("cloud"));
+  cloud_has_intensity_ = pnh_.param("cloud_has_intensity", false);
+  free_intensity_ = pnh_.param("free_intensity", 0.0);
+  lethal_intensity_ = pnh_.param("lethal_intensity", 1.0);
+  double data_valid_duration = pnh_.param("data_valid_duration", 0.0);
+  data_valid_duration_ = ros::Duration(data_valid_duration);
+
+  ROS_INFO_STREAM("PointCloudLayer3D " << name << ": initializing");
+  ROS_INFO_STREAM("  cloud_topic: " << cloud_topic_);
+  ROS_INFO_STREAM("  cloud_has_intensity: " << cloud_has_intensity_);
+  if (cloud_has_intensity_)
+  {
+    ROS_INFO_STREAM("  free_intensity: " << free_intensity_);
+    ROS_INFO_STREAM("  lethal_intensity: " << lethal_intensity_);
+  }
+
+  dsrv_.reset(new dynamic_reconfigure::Server<costmap_3d::GenericPluginConfig>(pnh_));
+  dsrv_->setCallback(std::bind(&PointCloudLayer3D::reconfigureCallback, this,
+                               std::placeholders::_1, std::placeholders::_2));
+
+  activate();
+}
+
+void PointCloudLayer3D::reconfigureCallback(costmap_3d::GenericPluginConfig &config, uint32_t level)
+{
+  std::lock_guard<Layer3D> lock(*this);
+  enabled_ = config.enabled;
+  combination_method_ = config.combination_method;
+}
+
+void PointCloudLayer3D::updateBounds(
+    const geometry_msgs::Pose robot_pose,
+    const geometry_msgs::Point& rolled_min,
+    const geometry_msgs::Point& rolled_max,
+    Costmap3D* bounds_map)
+{
+  std::lock_guard<Layer3D> lock(*this);
+  bool current = true;
+  if (data_valid_duration_ > ros::Duration(0.0))
+  {
+    if (ros::Time::now() - last_update_stamp_ > data_valid_duration_)
+    {
+      ROS_WARN_STREAM_THROTTLE(1.0, "Layer " << name_ << " point cloud not updated for "
+                               << (ros::Time::now() - last_update_stamp_).toSec()
+                               << " expected update in at least " <<  data_valid_duration_.toSec());
+      current = false;
+    }
+  }
+  current_ = current;
+  super::updateBounds(robot_pose, rolled_min, rolled_max, bounds_map);
+}
+
+
+void PointCloudLayer3D::deactivate()
+{
+  std::lock_guard<Layer3D> lock(*this);
+  active_ = false;
+  unsubscribe();
+  super::deactivate();
+}
+
+void PointCloudLayer3D::activate()
+{
+  std::lock_guard<Layer3D> lock(*this);
+  super::activate();
+  subscribe();
+  active_ = true;
+}
+
+void PointCloudLayer3D::subscribe()
+{
+  if (cloud_has_intensity_)
+  {
+    cloud_sub_ = pnh_.subscribe<PointCloudWithIntensity>(
+        cloud_topic_, 1, std::bind(&PointCloudLayer3D::pointCloudCallback<PointCloudWithIntensity>,
+                                   this, std::placeholders::_1));
+  }
+  else
+  {
+    cloud_sub_ = pnh_.subscribe<PointCloud>(
+        cloud_topic_, 1, std::bind(&PointCloudLayer3D::pointCloudCallback<PointCloud>,
+                                   this, std::placeholders::_1));
+  }
+}
+
+void PointCloudLayer3D::unsubscribe()
+{
+  cloud_sub_.shutdown();
+}
+
+template <typename PointType>
+Cost PointCloudLayer3D::pointIntensityToCost(PointType point)
+{
+  // default is all points are lethal
+  return LETHAL;
+}
+
+template <>
+Cost PointCloudLayer3D::pointIntensityToCost<pcl::PointXYZI>(pcl::PointXYZI point)
+{
+  const float intensity = point.intensity;
+  if (intensity >= lethal_intensity_)
+    return LETHAL;
+  if (intensity <= free_intensity_)
+    return FREE;
+  // Linearly interpolate the intensity value to the space between LETHAL and FREE
+  return ((intensity - free_intensity_) / (lethal_intensity_ - free_intensity_)) * (LETHAL - FREE) + FREE;
+}
+
+template <typename CloudType>
+void PointCloudLayer3D::pointCloudCallback(const typename CloudType::ConstPtr& cloud_msg)
+{
+  // Find the global frame transform.
+  ros::Time stamp(pcl_conversions::fromPCL(cloud_msg->header.stamp));
+  tf::StampedTransform global_frame_transform;
+  try
+  {
+    tf_->lookupTransform(layered_costmap_3d_->getGlobalFrameID(),
+                         cloud_msg->header.frame_id,
+                         stamp,
+                         global_frame_transform);
+  }
+  catch (tf::TransformException ex)
+  {
+    ROS_INFO_STREAM_THROTTLE(1.0, "unable to transform: " << ex.what());
+    return;
+  }
+  Eigen::Affine3d global_frame_transform_eigen;
+  tf::transformTFToEigen(global_frame_transform, global_frame_transform_eigen);
+  typename CloudType::Ptr cloud_ptr(new CloudType());
+  pcl::transformPointCloud(*cloud_msg, *cloud_ptr, global_frame_transform_eigen);
+
+  std::lock_guard<Layer3D> lock(*this);
+  if (active_ && costmap_)
+  {
+    last_update_stamp_ = stamp;
+    Costmap3D new_cells(costmap_->getResolution());
+    for (auto pt : cloud_msg->points)
+    {
+      Cost pt_cost = pointIntensityToCost(pt);
+      geometry_msgs::Point point;
+      point.x = pt.x;
+      point.y = pt.y;
+      point.z = pt.z;
+      Costmap3DIndex key;
+      if (new_cells.coordToKeyChecked(toOctomapPoint(point), key))
+      {
+        Costmap3D::NodeType* node = new_cells.search(key);
+        // Only set the maximum cost for a given key across the cloud
+        if (!node || node->getValue() < pt_cost)
+        {
+          new_cells.setNodeValue(key, pt_cost);
+        }
+      }
+    }
+
+    // Copy the old costmap state into erase cells
+    Costmap3D erase_cells(*costmap_);
+    // Delete any cells from erase_cells that are in the new cloud.
+    erase_cells.setTreeValues(NULL, &new_cells, false, true);
+
+    // Add any cells in new_cells to unchanged_cells that match our current costmap state.
+    Costmap3D unchanged_cells(costmap_->getResolution());
+    for(Costmap3D::leaf_iterator it=new_cells.begin_leafs(), end=new_cells.end_leafs(); it != end; ++it)
+    {
+      const Costmap3DIndex key(it.getKey());
+      const Cost new_cost = it->getValue();
+      const Costmap3D::NodeType* const old_node = costmap_->search(key);
+      if (old_node && new_cost == old_node->getValue())
+      {
+	unchanged_cells.setNodeValue(key, new_cost);
+      }
+    }
+
+    // Remove the unchanged cells from the new cells to avoid over-touching the costmap
+    new_cells.setTreeValues(NULL, &unchanged_cells, false, true);
+
+    // Make the changes
+    eraseCells(erase_cells);
+    markAndClearCells(new_cells);
+  }
+}
+
+}  // namespace costmap_3d

--- a/costmap_3d/scripts/get_current_pose_distance_3d.py
+++ b/costmap_3d/scripts/get_current_pose_distance_3d.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+"""
+Test the performance of 3D costmap by sending a veyr large get plan cost service requests.
+"""
+
+import sys
+import math
+import random
+import rospy
+import tf2_ros
+import tf2_geometry_msgs
+import tf.transformations
+import costmap_3d.srv
+import geometry_msgs.msg
+import copy
+
+
+if __name__ == "__main__":
+
+    rospy.init_node("test_costmap3d_get_plan_cost_performance", anonymous=True)
+
+    tfBuffer = tf2_ros.Buffer()
+    tfListener = tf2_ros.TransformListener(tfBuffer)
+
+    try:
+        xform = tfBuffer.lookup_transform('odom', 'base_footprint',
+                rospy.Time(0.0), rospy.Duration(10.0))
+
+    except tf2_ros.TransformException as e:
+        rospy.logerr("Cannot determine base footprint transform")
+        sys.exit(1)
+
+    get_cost_srv = rospy.ServiceProxy("/move_base/local_costmap/get_plan_cost_3d",
+            costmap_3d.srv.GetPlanCost3DService)
+    pose_array = geometry_msgs.msg.PoseArray()
+    pose_array.header.frame_id = "odom"
+    pose_array.header.stamp = rospy.Time.now()
+    req = costmap_3d.srv.GetPlanCost3DServiceRequest()
+    req.lazy = False
+    req.buffered = True
+    req.header.frame_id = "odom"
+    req.header.stamp = pose_array.header.stamp
+    req.cost_query_mode = costmap_3d.srv.GetPlanCost3DServiceRequest.COST_QUERY_MODE_DISTANCE
+    req.footprint_mesh_resource = ""
+#    req.footprint_mesh_resource = "package://ant_description/meshes/robot-get-close-to-obstacle-backward.stl"
+#    req.padding = 0.0
+    req.padding = float('NaN')
+    pose = geometry_msgs.msg.PoseStamped()
+    pose.header.frame_id = "base_footprint"
+    pose.pose.position.x = 0.0
+    pose.pose.position.y = 0.0
+    pose.pose.position.z = 0.0
+    pose.pose.orientation.x = 0.0
+    pose.pose.orientation.y = 0.0
+    pose.pose.orientation.z = 0.0
+    pose.pose.orientation.w = 1.0
+    req.poses.append(tf2_geometry_msgs.do_transform_pose(pose, xform))
+#    rospy.loginfo("Request: " + str(req))
+    res = get_cost_srv(req)
+    rospy.loginfo("Result: " + str(res))
+    rospy.loginfo("Number of lethals: " + str(len(res.lethal_indices)))

--- a/costmap_3d/scripts/test_get_pose_cost.py
+++ b/costmap_3d/scripts/test_get_pose_cost.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+"""
+Test the performance of 3D costmap by sending a veyr large get plan cost service requests.
+"""
+
+import sys
+import math
+import random
+import rospy
+import tf2_ros
+import tf2_geometry_msgs
+import tf.transformations
+import costmap_monitor.srv
+import geometry_msgs.msg
+
+
+if __name__ == "__main__":
+
+    rospy.init_node("test_costmap3d_get_plan_cost_performance", anonymous=True)
+
+    tfBuffer = tf2_ros.Buffer()
+    tfListener = tf2_ros.TransformListener(tfBuffer)
+
+    try:
+        xform = tfBuffer.lookup_transform('odom', 'base_footprint',
+                rospy.Time(0.0), rospy.Duration(10.0))
+
+    except tf2_ros.TransformException as e:
+        rospy.logerr("Cannot determine base footprint transform")
+        sys.exit(1)
+
+    get_cost_srv = rospy.ServiceProxy("/move_base/local_costmap/costmap_monitor/get_plan_cost",
+            costmap_monitor.srv.GetPlanCostService)
+    req = costmap_monitor.srv.GetPlanCostServiceRequest()
+    req.lazy = False
+    req.header.frame_id = "odom"
+    req.padding = 0.0
+    pt = geometry_msgs.msg.Point()
+    pt.z = 0.0
+    pt.x = .372
+    pt.y = 0.0
+    req.footprint.append(pt)
+    pt.x = .368
+    pt.y = -.178
+    req.footprint.append(pt)
+    pt.x = .345
+    pt.y = -.235
+    req.footprint.append(pt)
+    pt.x = .293
+    pt.y = -.272
+    req.footprint.append(pt)
+    pt.x = .0114
+    pt.y = -.285
+    req.footprint.append(pt)
+    pt.x = -0.262
+    pt.y = -0.272
+    req.footprint.append(pt)
+    pt.x = -0.312
+    pt.y = -0.242
+    req.footprint.append(pt)
+    pt.x = -0.343
+    pt.y = -0.192
+    req.footprint.append(pt)
+    pt.x = -0.350
+    pt.y = 0.0
+    req.footprint.append(pt)
+    pt.x = -0.343
+    pt.y = 0.192
+    req.footprint.append(pt)
+    pt.x = -0.312
+    pt.y = 0.242
+    req.footprint.append(pt)
+    pt.x = -0.262
+    pt.y = 0.272
+    req.footprint.append(pt)
+    pt.x = 0.0114
+    pt.y = 0.285
+    req.footprint.append(pt)
+    pt.x = 0.293
+    pt.y = 0.272
+    req.footprint.append(pt)
+    pt.x = 0.345
+    pt.y = 0.235
+    req.footprint.append(pt)
+    pt.x = 0.368
+    pt.y = 0.178
+    req.footprint.append(pt)
+    for i in range(0,100000):
+        pose = geometry_msgs.msg.PoseStamped()
+        pose.header.frame_id = "base_footprint"
+        pose.pose.position.x = random.uniform(-4.0, 4.0)
+        pose.pose.position.y = random.uniform(-4.0, 4.0)
+        pose.pose.position.z = 0.0
+        theta = random.uniform(-math.pi, math.pi)
+        q = tf.transformations.quaternion_from_euler(0.0, 0.0, theta)
+        pose.pose.orientation.x = q[0]
+        pose.pose.orientation.y = q[1]
+        pose.pose.orientation.z = q[2]
+        pose.pose.orientation.w = q[3]
+        req.poses.append(tf2_geometry_msgs.do_transform_pose(pose, xform))
+
+    res = get_cost_srv(req)
+    rospy.loginfo("Result: " + str(res))

--- a/costmap_3d/scripts/test_get_pose_cost_3d.py
+++ b/costmap_3d/scripts/test_get_pose_cost_3d.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python
+"""
+Test the performance of 3D costmap by sending a veyr large get plan cost service requests.
+"""
+
+import sys
+import math
+import random
+import rospy
+import tf2_ros
+import tf2_geometry_msgs
+import tf.transformations
+import costmap_3d.srv
+import geometry_msgs.msg
+import copy
+
+
+if __name__ == "__main__":
+
+    rospy.init_node("test_costmap3d_get_plan_cost_performance", anonymous=True)
+
+    tfBuffer = tf2_ros.Buffer()
+    tfListener = tf2_ros.TransformListener(tfBuffer)
+
+    try:
+        xform = tfBuffer.lookup_transform('odom', 'base_footprint',
+                rospy.Time(0.0), rospy.Duration(10.0))
+
+    except tf2_ros.TransformException as e:
+        rospy.logerr("Cannot determine base footprint transform")
+        sys.exit(1)
+
+    pose_array_pub = rospy.Publisher("/test_costmap_3d/pose_array", geometry_msgs.msg.PoseArray, queue_size=1)
+    get_cost_srv = rospy.ServiceProxy("/test_costmap_3d/costmap/get_plan_cost_3d",
+            costmap_3d.srv.GetPlanCost3DService)
+    pose_array = geometry_msgs.msg.PoseArray()
+    pose_array.header.frame_id = "odom"
+    pose_array.header.stamp = rospy.Time.now()
+    req = costmap_3d.srv.GetPlanCost3DServiceRequest()
+    req.lazy = False
+    req.buffered = True
+    req.header.frame_id = "odom"
+    req.header.stamp = pose_array.header.stamp
+    req.cost_query_mode = costmap_3d.srv.GetPlanCost3DServiceRequest.COST_QUERY_MODE_DISTANCE
+    req.footprint_mesh_resource = ""
+#    req.footprint_mesh_resource = "package://ant_description/meshes/robot-get-close-to-obstacle-backward.stl"
+    req.padding = 0.0
+#    req.padding = 0.25
+#    for i in range(0,35*4*5*8):
+    for teb in range(0,4):
+#    for teb in range(0,60*4):
+        pose = geometry_msgs.msg.PoseStamped()
+        pose.header.frame_id = "base_footprint"
+#        pose.pose.position.x = random.uniform(-4.0, 4.0)
+#        pose.pose.position.y = random.uniform(-4.0, 4.0)
+        pose.pose.position.x = 0.0
+        pose.pose.position.y = 0.0
+        pose.pose.position.z = 0.0
+        # pick a random direction to travel in
+        path_theta = random.uniform(-math.pi, math.pi)
+        path_poses = []
+        while math.hypot(pose.pose.position.x, pose.pose.position.y) < 4.0:
+            q = tf.transformations.quaternion_from_euler(0.0, 0.0, path_theta)
+            pose.pose.orientation.x = q[0]
+            pose.pose.orientation.y = q[1]
+            pose.pose.orientation.z = q[2]
+            pose.pose.orientation.w = q[3]
+            path_poses.append(copy.deepcopy(pose))
+            # Simulate motion in path theta
+            d = random.gauss(.075, .01)
+            pose.pose.position.x += d*math.cos(path_theta)
+            pose.pose.position.y += d*math.sin(path_theta)
+            # Pick a new path theta
+            path_theta = random.gauss(path_theta, math.pi/36)
+
+        # Simulate 15Hz planning loop and 5Hz map update dumping distance cache
+        for planning_loop in range(0,3):
+            # Simulate optimization step
+            for optimization_step in range(0,20):
+                for i in range(0,len(path_poses)):
+                    path_pose = path_poses[i]
+                    path_pose.pose.position.x += random.gauss(0, .25/(2.7**(optimization_step+planning_loop)))
+                    path_pose.pose.position.y += random.gauss(0, .25/(2.7**(optimization_step+planning_loop)))
+                    if path_pose.pose.position.x > 4.0:
+                        path_pose.pose.position.x = 4.0
+                    if path_pose.pose.position.x < -4.0:
+                        path_pose.pose.position.x = -4.0
+                    if path_pose.pose.position.y > 4.0:
+                        path_pose.pose.position.y = 4.0
+                    if path_pose.pose.position.y < -4.0:
+                        path_pose.pose.position.y = -4.0
+                    q = tf.transformations.quaternion_from_euler(0.0, 0.0, 0.0)
+                    q[0] = path_pose.pose.orientation.x
+                    q[1] = path_pose.pose.orientation.y
+                    q[2] = path_pose.pose.orientation.z
+                    q[3] = path_pose.pose.orientation.w
+                    theta = tf.transformations.euler_from_quaternion(q)[2]
+                    theta += random.gauss(0, (math.pi/36)/(2**(optimization_step+planning_loop)))
+                    q = tf.transformations.quaternion_from_euler(0.0, 0.0, theta)
+                    path_pose.pose.orientation.x = q[0]
+                    path_pose.pose.orientation.y = q[1]
+                    path_pose.pose.orientation.z = q[2]
+                    path_pose.pose.orientation.w = q[3]
+                    # necessary?
+                    path_poses[i] = copy.deepcopy(path_pose)
+                    orig_pose = path_pose
+                    req.poses.append(tf2_geometry_msgs.do_transform_pose(orig_pose, xform))
+                    pose_array.poses.append(tf2_geometry_msgs.do_transform_pose(orig_pose, xform).pose)
+                    # simulate calls for jacobian
+                    path_pose.pose.position.x += .000001
+                    req.poses.append(tf2_geometry_msgs.do_transform_pose(path_pose, xform))
+                    pose_array.poses.append(tf2_geometry_msgs.do_transform_pose(path_pose, xform).pose)
+                    path_pose.pose.position.x -= .000001
+                    path_pose.pose.position.y += .000001
+        #            req.poses.append(tf2_geometry_msgs.do_transform_pose(orig_pose, xform))
+                    req.poses.append(tf2_geometry_msgs.do_transform_pose(path_pose, xform))
+                    pose_array.poses.append(tf2_geometry_msgs.do_transform_pose(path_pose, xform).pose)
+                    path_pose.pose.position.y -= .000001
+                    theta += .000006283
+                    q = tf.transformations.quaternion_from_euler(0.0, 0.0, theta)
+                    path_pose.pose.orientation.x = q[0]
+                    path_pose.pose.orientation.y = q[1]
+                    path_pose.pose.orientation.z = q[2]
+                    path_pose.pose.orientation.w = q[3]
+        #            req.poses.append(tf2_geometry_msgs.do_transform_pose(orig_pose, xform))
+                    req.poses.append(tf2_geometry_msgs.do_transform_pose(path_pose, xform))
+                    pose_array.poses.append(tf2_geometry_msgs.do_transform_pose(path_pose, xform).pose)
+
+    pose_array_pub.publish(pose_array)
+#    rospy.loginfo("Request: " + str(req))
+    res = get_cost_srv(req)
+    rospy.loginfo("Result: " + str(res))
+    rospy.loginfo("Number of lethals: " + str(len(res.lethal_indices)))
+    rospy.spin()

--- a/costmap_3d/src/costmap_3d.cpp
+++ b/costmap_3d/src/costmap_3d.cpp
@@ -1,0 +1,77 @@
+/*********************************************************************
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Badger Technologies LLC
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: C. Andy Martin
+ *********************************************************************/
+
+#include <costmap_3d/costmap_3d.h>
+
+namespace costmap_3d
+{
+
+Costmap3D::Costmap3D(double resolution) : octomap::OcTree(resolution)
+{
+  setProbHit(octomap::probability(LETHAL-FREE));
+  setProbMiss(octomap::probability(FREE-LETHAL));
+  setClampingThresMin(octomap::probability(FREE));
+  setClampingThresMax(octomap::probability(LETHAL));
+  // By default, only lethal cells are considered occupied
+  setOccupancyThres(octomap::probability(LETHAL));
+  // TODO: FCL has an OcTree wrapper class that defines both a free threshold
+  // and an occupied threshold.
+  // It copies the lethal threshold, but defaults to a 0 probability for the
+  // free threshold (i.e., cells are never free!).
+  // However, the MoveIt interfaces currently provide no way to set the FCL
+  // properties.
+  // We need a way to change this to 0.5 (0 log odds) to get the cost to be
+  // accurate.
+  // This isn't a big deal for non-cost queries (such as binary collision or
+  // distance queries).
+}
+
+octomap::point3d toOctomapPoint(const geometry_msgs::Point& point)
+{
+  return octomap::point3d((float)point.x, (float)point.y, (float)point.z);
+}
+
+geometry_msgs::Point fromOctomapPoint(const octomap::point3d& point)
+{
+  geometry_msgs::Point p;
+  p.x = point.x();
+  p.y = point.y();
+  p.z = point.z();
+  return p;
+}
+
+}  // namespace costmap_3d

--- a/costmap_3d/src/costmap_3d_node.cpp
+++ b/costmap_3d/src/costmap_3d_node.cpp
@@ -1,0 +1,98 @@
+/*********************************************************************
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Badger Technologies LLC
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: C. Andy Martin
+ *********************************************************************/
+#include <ros/ros.h>
+#include <std_srvs/Empty.h>
+#include <std_srvs/Empty.h>
+#include <octomap_msgs/BoundingBoxQuery.h>
+#include <costmap_3d/costmap_3d_ros.h>
+
+costmap_3d::Costmap3DROS* g_costmap_ptr;
+
+bool stopService(std_srvs::EmptyRequest& req, std_srvs::EmptyResponse& resp)
+{
+  if (g_costmap_ptr)
+  {
+    g_costmap_ptr->stop();
+  }
+  return true;
+}
+
+bool startService(std_srvs::EmptyRequest& req, std_srvs::EmptyResponse& resp)
+{
+  if (g_costmap_ptr)
+  {
+    g_costmap_ptr->start();
+  }
+  return true;
+}
+
+bool resetService(std_srvs::EmptyRequest& req, std_srvs::EmptyResponse& resp)
+{
+  if (g_costmap_ptr)
+  {
+    g_costmap_ptr->resetLayers();
+  }
+  return true;
+}
+
+bool eraseBBoxService(octomap_msgs::BoundingBoxQueryRequest& req, octomap_msgs::BoundingBoxQueryResponse& resp)
+{
+  if (g_costmap_ptr)
+  {
+    g_costmap_ptr->resetBoundingBox(req.min, req.max);
+  }
+  return true;
+}
+
+
+int main(int argc, char* argv[])
+{
+  ros::init(argc, argv, "costmap_3d_node");
+  ros::NodeHandle pnh("~");
+  tf::TransformListener tf(ros::Duration(10));
+  costmap_3d::Costmap3DROS costmap("costmap", tf);
+  g_costmap_ptr = &costmap;
+
+  auto reset_srv = pnh.advertiseService("reset", resetService);
+  auto stop_srv = pnh.advertiseService("stop", stopService);
+  auto start_srv = pnh.advertiseService("start", startService);
+  auto erase_bbx_srv = pnh.advertiseService("erase_bbx", eraseBBoxService);
+
+  ros::spin();
+
+  return 0;
+}

--- a/costmap_3d/src/costmap_3d_publisher.cpp
+++ b/costmap_3d/src/costmap_3d_publisher.cpp
@@ -1,0 +1,145 @@
+/*********************************************************************
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Badger Technologies LLC
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: C. Andy Martin
+ *********************************************************************/
+#include <costmap_3d/costmap_3d_publisher.h>
+#include <octomap_msgs/conversions.h>
+
+namespace costmap_3d
+{
+
+Costmap3DPublisher::Costmap3DPublisher(const ros::NodeHandle& nh,
+                                       LayeredCostmap3D* layered_costmap_3d,
+                                       std::string topic_name)
+    : nh_(nh), layered_costmap_3d_(layered_costmap_3d)
+{
+  costmap_pub_ = nh_.advertise<octomap_msgs::Octomap>(topic_name, 1);
+  costmap_update_pub_ = nh_.advertise<octomap_msgs::OctomapUpdate>(topic_name + "_updates", 3,
+                                                      std::bind(&Costmap3DPublisher::connectCallback, this,
+                                                                std::placeholders::_1));
+
+  update_complete_id = topic_name + "_publisher";
+  layered_costmap_3d_->registerUpdateCompleteCallback(update_complete_id,
+                                                      std::bind(&Costmap3DPublisher::updateCompleteCallback, this,
+                                                                std::placeholders::_1,
+                                                                std::placeholders::_2,
+                                                                std::placeholders::_3));
+}
+
+Costmap3DPublisher::~Costmap3DPublisher()
+{
+  layered_costmap_3d_->unregisterUpdateCompleteCallback(update_complete_id);
+}
+
+void Costmap3DPublisher::connectCallback(const ros::SingleSubscriberPublisher& pub)
+{
+  Costmap3D universe(layered_costmap_3d_->getResolution());
+  universe.setNodeValueAtDepth(Costmap3DIndex(), 0, LETHAL);
+  octomap_msgs::OctomapUpdatePtr msg_ptr;
+
+  // Be sure to lock the costmap while using it, and keep it locked until
+  // we have published the state, otherwise a race can occur when the
+  // map update complete callback publishes and the two messages could
+  // end up out-of-order
+  std::lock_guard<LayeredCostmap3D> costmap_lock(*layered_costmap_3d_);
+  // Send an "update" message with universal bounds and the entire costmap.
+  // This way, a new subscriber starts with the correct map state.
+  msg_ptr = createMapUpdateMessage(*layered_costmap_3d_->getCostmap3D(), universe, true);
+
+  pub.publish(msg_ptr);
+}
+
+void Costmap3DPublisher::updateCompleteCallback(LayeredCostmap3D* layered_costmap_3d,
+                                                const Costmap3D& delta_map,
+                                                const Costmap3D& bounds_map)
+{
+  // The layered costmap already holds the lock when calling the update
+  // complete, no need to lock
+  if (costmap_pub_.getNumSubscribers() > 0)
+  {
+    octomap_msgs::OctomapPtr msg_ptr(createMapMessage(*layered_costmap_3d_->getCostmap3D()));
+    costmap_pub_.publish(msg_ptr);
+  }
+  if (costmap_update_pub_.getNumSubscribers() > 0)
+  {
+    octomap_msgs::OctomapUpdatePtr msg_ptr(createMapUpdateMessage(delta_map, bounds_map));
+    costmap_update_pub_.publish(msg_ptr);
+  }
+}
+
+octomap_msgs::OctomapPtr Costmap3DPublisher::createMapMessage(const Costmap3D& map)
+{
+  ros::Time stamp = ros::Time::now();
+  std::string frame = layered_costmap_3d_->getGlobalFrameID();
+  octomap_msgs::OctomapPtr msg_ptr(new octomap_msgs::Octomap);
+  msg_ptr->header.frame_id = frame;
+  msg_ptr->header.stamp = stamp;
+  octomap_msgs::fullMapToMsg(map, *msg_ptr);
+  return msg_ptr;
+}
+
+octomap_msgs::OctomapUpdatePtr Costmap3DPublisher::createMapUpdateMessage(const Costmap3D& value_map,
+                                                                          const Costmap3D& bounds_map,
+                                                                          bool first_map)
+{
+  ros::Time stamp = ros::Time::now();
+  std::string frame = layered_costmap_3d_->getGlobalFrameID();
+  octomap_msgs::OctomapUpdatePtr msg_ptr(new octomap_msgs::OctomapUpdate);
+  msg_ptr->header.frame_id = frame;
+  msg_ptr->header.stamp = stamp;
+  msg_ptr->octomap_update.header.seq = update_seq_;
+  msg_ptr->octomap_update.header.frame_id = frame;
+  msg_ptr->octomap_update.header.stamp = stamp;
+  msg_ptr->octomap_bounds.header.seq = update_seq_;
+  msg_ptr->octomap_bounds.header.frame_id = frame;
+  msg_ptr->octomap_bounds.header.stamp = stamp;
+  if (first_map)
+  {
+    // On the first map, make the sequences unequal as sentinel
+    msg_ptr->octomap_bounds.header.seq--;
+  }
+  else
+  {
+    // On regular map message, increment the sequence number
+    update_seq_++;
+  }
+  // always send costs along with map
+  octomap_msgs::fullMapToMsg(value_map, msg_ptr->octomap_update);
+  // bounds map is only ever binary
+  octomap_msgs::binaryMapToMsg(bounds_map, msg_ptr->octomap_bounds);
+  return msg_ptr;
+}
+
+}  // end namespace costmap_2d

--- a/costmap_3d/src/costmap_3d_query.cpp
+++ b/costmap_3d/src/costmap_3d_query.cpp
@@ -1,0 +1,385 @@
+/*********************************************************************
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Badger Technologies LLC
+ *  All rights reserved.
+  *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: C. Andy Martin
+ *********************************************************************/
+#include <costmap_3d/costmap_3d_query.h>
+#include <fcl/geometry/octree/octree.h>
+#include <fcl/narrowphase/collision.h>
+#include <fcl/narrowphase/distance_result.h>
+#include <fcl/geometry/shape/sphere.h>
+#include <pcl/io/vtk_lib_io.h>
+#include <ros/ros.h>
+#include <ros/package.h>
+#include <tf/transform_datatypes.h>
+
+namespace costmap_3d
+{
+
+Costmap3DQuery::Costmap3DQuery(
+    const LayeredCostmap3D* layered_costmap_3d,
+    const std::string& mesh_resource,
+    double padding,
+    unsigned int pose_bins_per_meter,
+    unsigned int pose_bins_per_radian,
+    unsigned int pose_micro_bins_per_meter,
+    unsigned int pose_micro_bins_per_radian)
+  : layered_costmap_3d_(layered_costmap_3d),
+    pose_bins_per_meter_(pose_bins_per_meter),
+    pose_bins_per_radian_(pose_bins_per_radian),
+    pose_micro_bins_per_meter_(pose_micro_bins_per_meter),
+    pose_micro_bins_per_radian_(pose_micro_bins_per_radian)
+{
+  updateMeshResource(mesh_resource, padding);
+}
+
+Costmap3DQuery::Costmap3DQuery(const Costmap3DConstPtr& costmap_3d,
+    const std::string& mesh_resource,
+    double padding,
+    unsigned int pose_bins_per_meter,
+    unsigned int pose_bins_per_radian,
+    unsigned int pose_micro_bins_per_meter,
+    unsigned int pose_micro_bins_per_radian)
+  : pose_bins_per_meter_(pose_bins_per_meter),
+    pose_bins_per_radian_(pose_bins_per_radian),
+    pose_micro_bins_per_meter_(pose_micro_bins_per_meter),
+    pose_micro_bins_per_radian_(pose_micro_bins_per_radian)
+{
+  // Make a local copy of the costmap in question
+  // It would be awesome if the Costmap3D had a way to snapshot
+  // or copy-on-write. As it stands, for many scenarios involving
+  // space-limited local costmaps, copying a 3D costmap will only take a
+  // couple millseconds and is better than leaving the costmap locked for
+  // an entire planning cycle.
+  octree_ptr_.reset(new Costmap3D(*costmap_3d));
+  std::shared_ptr<fcl::OcTree<FCLFloat>> fcl_octree_ptr;
+  fcl_octree_ptr.reset(new fcl::OcTree<FCLFloat>(octree_ptr_));
+  world_obj_ = FCLCollisionObjectPtr(new fcl::CollisionObject<FCLFloat>(fcl_octree_ptr));
+  updateMeshResource(mesh_resource, padding);
+}
+
+// Be sure to deep-copy any object with state that we modify.
+Costmap3DQuery::Costmap3DQuery(const Costmap3DQuery& rhs)
+  : // Share a pointer to the layered_costmap_3d_
+    layered_costmap_3d_(rhs.layered_costmap_3d_),
+    // Copy the pose-bin constants
+    pose_bins_per_meter_(rhs.pose_bins_per_meter_),
+    pose_bins_per_radian_(rhs.pose_bins_per_radian_),
+    pose_micro_bins_per_meter_(rhs.pose_micro_bins_per_meter_),
+    pose_micro_bins_per_radian_(rhs.pose_micro_bins_per_radian_),
+    // Share a pointer to the robot model
+    robot_model_(rhs.robot_model_),
+    // Create a new robot_obj_, as we need to modify the transform.
+    robot_obj_(new FCLCollisionObject(robot_model_)),
+    // Share a pointer to the octree (if there was one)
+    octree_ptr_(rhs.octree_ptr_),
+    // Start out sharing a pointer to the world object.
+    // (We may make our own if the layered_costmap_3d_'s costmap is re-created)
+    world_obj_(rhs.world_obj_)
+    // Do NOT copy our caches as we do not synchrnoize.
+    // The whole point of this copy constructor is so multiple planning
+    // threads could be querying the same octomap with separate caches in
+    // order to avoid locking.
+{
+}
+
+Costmap3DQuery::~Costmap3DQuery()
+{
+}
+
+void Costmap3DQuery::checkCostmap()
+{
+  if (layered_costmap_3d_)
+  {
+    if (layered_costmap_3d_->getCostmap3D() != octree_ptr_)
+    {
+      // The octomap has been reallocated, change where we are pointing.
+      octree_ptr_ = layered_costmap_3d_->getCostmap3D();
+      std::shared_ptr<fcl::OcTree<FCLFloat>> fcl_octree_ptr;
+      fcl_octree_ptr.reset(new fcl::OcTree<FCLFloat>(octree_ptr_));
+      world_obj_ = FCLCollisionObjectPtr(new fcl::CollisionObject<FCLFloat>(fcl_octree_ptr));
+    }
+    // The costmap has been updated since the last query, reset our caches
+    if (last_layered_costmap_update_number_ != layered_costmap_3d_->getNumberOfUpdates())
+    {
+      // For simplicity, on every update, clear out the collision cache.
+      // This is not strictly necessary. The mesh is stored in the cache and does
+      // not change. The only thing that is changing is the costmap. We could go
+      // through the delta map and only remove entries that have had the
+      // corresponding octomap cell go away. This may be implemented as a future
+      // improvement.
+      distance_cache_.clear();
+      micro_distance_cache_.clear();
+    }
+    last_layered_costmap_update_number_ = layered_costmap_3d_->getNumberOfUpdates();
+  }
+}
+
+void Costmap3DQuery::addPCLPolygonToFCLTriangles(
+    const pcl::Vertices& polygon,
+    std::vector<fcl::Triangle>* fcl_triangles)
+{
+  // Assume the polygons are convex. Break them into triangles.
+  const std::size_t zero_index = polygon.vertices[0];
+  for (int i=1; i < polygon.vertices.size() - 1; ++i)
+  {
+    fcl_triangles->push_back(fcl::Triangle(zero_index, polygon.vertices[i], polygon.vertices[i+1]));
+  }
+}
+
+
+void Costmap3DQuery::addPCLPolygonMeshToRobotModel(
+    const pcl::PolygonMesh& pcl_mesh,
+    double padding,
+    FCLRobotModel* robot_model)
+{
+  pcl::PointCloud<pcl::PointXYZ> mesh_points;
+  pcl::fromPCLPointCloud2(pcl_mesh.cloud, mesh_points);
+
+  std::vector<fcl::Vector3<FCLFloat>> fcl_points;
+  std::vector<fcl::Triangle> fcl_triangles;
+
+  for (auto pcl_point : mesh_points)
+  {
+    fcl_points.push_back(padPCLPointToFCL(pcl_point, padding));
+  }
+
+  for (auto polygon : pcl_mesh.polygons)
+  {
+    addPCLPolygonToFCLTriangles(polygon, &fcl_triangles);
+  }
+
+  robot_model->addSubModel(fcl_points, fcl_triangles);
+}
+
+void Costmap3DQuery::updateMeshResource(const std::string& mesh_resource, double padding)
+{
+  std::string filename = getFileNameFromPackageURL(mesh_resource);
+  if (filename.size() == 0)
+  {
+    return;
+  }
+  pcl::PolygonMesh mesh;
+  int pcl_rv = pcl::io::loadPolygonFileSTL(filename, mesh);
+  if (pcl_rv < 0)
+  {
+    ROS_ERROR_STREAM("Costmap3DQuery: unable to load STL mesh file " << filename
+                     << " query object will always return collision!");
+    return;
+  }
+  robot_model_.reset(new FCLRobotModel());
+  robot_model_->beginModel();
+  addPCLPolygonMeshToRobotModel(mesh, padding, robot_model_.get());
+  robot_model_->endModel();
+  robot_obj_ = FCLCollisionObjectPtr(new FCLCollisionObject(robot_model_));
+}
+
+std::string Costmap3DQuery::getFileNameFromPackageURL(const std::string& url)
+{
+  /* Unfortunately the resource retriever does not have a way to get a path from a URL
+   * (it only returns the contents of a URL in memory), and equally unfortunate, PCL does not
+   * have a way to parse an STL from memory. Therefore we have to duplicate some of the
+   * (slightly-modified) resource retriever code here. */
+  // Reference: https://github.com/ros/resource_retriever/blob/kinetic-devel/src/retriever.cpp
+  std::string mod_url = url;
+  if (url.find("package://") == 0)
+  {
+    mod_url.erase(0, strlen("package://"));
+    size_t pos = mod_url.find("/");
+    if (pos == std::string::npos)
+    {
+      ROS_ERROR_STREAM("Costmap3DQuery: Could not parse package:// format URL "
+                       << url
+                       << " query object will always return collision!");
+      return "";
+    }
+
+    std::string package = mod_url.substr(0, pos);
+    mod_url.erase(0, pos);
+    std::string package_path = ros::package::getPath(package.c_str());
+
+    if (package_path.empty())
+    {
+      ROS_ERROR_STREAM("Costmap3DQuery: Package [" << package << "] from URL "
+                       << url << " does not exist, "
+                       << " query object will always return collision!");
+      return "";
+    }
+
+    mod_url = package_path + mod_url;
+  }
+  else if (url.find("file://") == 0)
+  {
+    mod_url.erase(0, strlen("file://"));
+  }
+
+  return mod_url;
+}
+
+double Costmap3DQuery::footprintCost(geometry_msgs::Pose pose)
+{
+  // TODO: implement as cost query. For now, just translate a collision to cost
+  return footprintCollision(pose) ? -1.0 : 0.0;
+}
+
+bool Costmap3DQuery::footprintCollision(geometry_msgs::Pose pose)
+{
+  if (!robot_obj_)
+  {
+    // We failed to create a robot model.
+    // The failure would have been logged, so simply return collision.
+    return true;
+  }
+  checkCostmap();
+  assert(world_obj_);
+
+  // FCL does not correctly handle an empty octomap.
+  if (octree_ptr_->size() == 0)
+  {
+    // There is nothing to collide, so there will be no collision
+    return false;
+  }
+
+  FCLCollisionObjectPtr robot(getRobotCollisionObject(pose));
+  FCLCollisionObjectPtr world(getWorldCollisionObject());
+
+  fcl::CollisionRequest<FCLFloat> request;
+  fcl::CollisionResult<FCLFloat> result;
+
+  fcl::collide(world.get(), robot.get(), request, result);
+
+  return result.isCollision();
+}
+
+double Costmap3DQuery::footprintDistance(geometry_msgs::Pose pose)
+{
+  if (!robot_obj_)
+  {
+    // We failed to create a robot model.
+    // The failure would have been logged, so simply return collision.
+    return -1.0;
+  }
+  checkCostmap();
+  assert(world_obj_);
+
+  // FCL does not correctly handle an empty octomap.
+  if (octree_ptr_->size() == 0)
+  {
+    return std::numeric_limits<double>::max();
+  }
+
+  FCLCollisionObjectPtr robot(getRobotCollisionObject(pose));
+  FCLCollisionObjectPtr world(getWorldCollisionObject());
+
+  FCLFloat pose_distance = std::numeric_limits<FCLFloat>::max();
+
+  DistanceCacheKey micro_cache_key(pose, pose_micro_bins_per_meter_, pose_micro_bins_per_radian_);
+  // if we hit the micro cache, use the result directly.
+  auto micro_cache_entry = micro_distance_cache_.find(micro_cache_key);
+  if (micro_cache_entry != micro_distance_cache_.end())
+  {
+    return micro_cache_entry->second.distanceToNewPose(pose);
+  }
+
+  fcl::DistanceRequest<FCLFloat> request;
+  fcl::DistanceResult<FCLFloat> result;
+
+  DistanceCacheKey cache_key(pose, pose_bins_per_meter_, pose_bins_per_radian_);
+  auto cache_entry = distance_cache_.find(cache_key);
+  if (cache_entry != distance_cache_.end())
+  {
+    // Cache hit, find the distance between the mesh triangle at the new pose
+    // and the octomap box, and use this as our initial guess in the result.
+    // This greatly prunes the search tree, yielding a big increase in runtime
+    // performance.
+    pose_distance = cache_entry->second.distanceToNewPose(pose);
+    cache_entry->second.setupResult(&result);
+  }
+  else if(distance_cache_.size() > 0)
+  {
+    // Cache miss, use the beginning of the cache to set the initial guess.
+    // This still prunes the search better than no initial guess in certain
+    // circumstances and is relatively cheap to calculate. This guess is still
+    // a correct upper bound, as the minimum distance must be less or equal to
+    // the mesh triangle at the new pose and the old nearest octomap cell.
+    auto begin = distance_cache_.begin();
+    pose_distance = begin->second.distanceToNewPose(pose);
+    begin->second.setupResult(&result);
+  }
+
+  request.enable_nearest_points = true;
+
+  result.min_distance = pose_distance;
+
+  double distance = fcl::distance(world.get(), robot.get(), request, result);
+
+  // Update distance caches
+  const DistanceCacheEntry& new_entry = DistanceCacheEntry(result);
+  distance_cache_[cache_key] = new_entry;
+  micro_distance_cache_[micro_cache_key] = new_entry;
+
+  return distance;
+}
+
+double Costmap3DQuery::footprintSignedDistance(geometry_msgs::Pose pose)
+{
+  if (!robot_obj_)
+  {
+    // We failed to create a robot model.
+    // The failure would have been logged, so simply return collision.
+    return -1.0;
+  }
+  checkCostmap();
+  // TODO: Figure out how to apply distance cache to signed distance.
+  // TODO: Think about how to make this work w/ meshes representing a solid and octomaps
+  assert(world_obj_);
+
+  // FCL does not correctly handle an empty octomap.
+  if (octree_ptr_->size() == 0)
+  {
+    return std::numeric_limits<double>::max();
+  }
+
+  FCLCollisionObjectPtr robot(getRobotCollisionObject(pose));
+  FCLCollisionObjectPtr world(getWorldCollisionObject());
+
+  fcl::DistanceRequest<FCLFloat> request;
+  fcl::DistanceResult<FCLFloat> result;
+
+  request.enable_signed_distance = true;
+
+  return fcl::distance(world.get(), robot.get(), request, result);
+}
+
+}  // namespace costmap_3d

--- a/costmap_3d/src/costmap_3d_ros.cpp
+++ b/costmap_3d/src/costmap_3d_ros.cpp
@@ -1,0 +1,483 @@
+/*********************************************************************
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Badger Technologies LLC
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: C. Andy Martin
+ *********************************************************************/
+// Uncomment to compile in auto profiling support for optimizing queries
+//#define COSTMAP_3D_ROS_AUTO_PROFILE_QUERY 1
+#if (COSTMAP_3D_ROS_AUTO_PROFILE_QUERY) > 0
+#include <sys/types.h>
+#include <unistd.h>
+#include <signal.h>
+#endif
+#include <cmath>
+#include <costmap_3d/costmap_3d_ros.h>
+#include <costmap_3d/layered_costmap_3d.h>
+#include <tf/transform_datatypes.h>
+#include <visualization_msgs/Marker.h>
+
+namespace costmap_3d
+{
+
+Costmap3DROS::Costmap3DROS(std::string name, tf::TransformListener& tf)
+  : super(name, tf),
+    private_nh_("~/" + name + "/"),
+    layered_costmap_3d_(layered_costmap_),
+    initialized_(false),
+    plugin_loader_("costmap_3d", "costmap_3d::Layer3D"),
+    publisher_(private_nh_, &layered_costmap_3d_, "costmap_3d"),
+    dsrv_(ros::NodeHandle("~/" + name + "/costmap_3d")),
+    get_plan_cost_action_srv_(
+        private_nh_,
+        "get_plan_cost_3d",
+        std::bind(&Costmap3DROS::getPlanCost3DActionCallback, this, std::placeholders::_1),
+        false)
+{
+  {
+    std::lock_guard<std::mutex> initialize_lock(initialized_mutex_);
+
+    if (!private_nh_.getParam("costmap_3d/footprint_mesh_resource", footprint_mesh_resource_))
+    {
+      ROS_ERROR("Unable to find footprint_mesh_resource parameter");
+    }
+
+    XmlRpc::XmlRpcValue my_list;
+    if (private_nh_.getParam("costmap_3d/plugins", my_list))
+    {
+      for (int32_t i = 0; i < my_list.size(); ++i)
+      {
+        std::string pname = static_cast<std::string>(my_list[i]["name"]);
+        std::string type = static_cast<std::string>(my_list[i]["type"]);
+
+        try
+        {
+          boost::shared_ptr<Layer3D> plugin = plugin_loader_.createInstance(type);
+          ROS_INFO_STREAM("3D costmap \"" << name << "\" "
+                          << "Using 3D plugin \"" << pname << "\" of type \"" << type << "\"");
+          plugin->initialize(&layered_costmap_3d_, name + "/costmap_3d/" + pname, &tf_);
+          layered_costmap_3d_.addPlugin(plugin);
+        }
+        catch (class_loader::ClassLoaderException e)
+        {
+          ROS_ERROR_STREAM("Unable to load plugin \"" << pname << "\" of type \"" << type << "\". "
+                           << "Error: " << e.what());
+        }
+      }
+    }
+    if (layered_costmap_3d_.getPlugins().size() == 0)
+    {
+      ROS_WARN_STREAM("3D costmap \"" << name << "\" has no 3D plugin layers, will be 2D only");
+    }
+    footprint_pub_ = private_nh_.advertise<visualization_msgs::Marker>("footprint_3d", 1, true);
+    initialized_ = true;
+  }
+
+  // Now that the object is initialized, advertise dynamic reconfigure and services
+  dsrv_.setCallback(
+      std::bind(
+          &Costmap3DROS::reconfigureCB,
+          this,
+          std::placeholders::_1,
+          std::placeholders::_2));
+
+  get_plan_cost_action_srv_.start();
+  get_plan_cost_srv_ = private_nh_.advertiseService(
+      "get_plan_cost_3d",
+      &Costmap3DROS::getPlanCost3DServiceCallback,
+      this);
+}
+
+Costmap3DROS::~Costmap3DROS()
+{
+}
+
+void Costmap3DROS::reconfigureCB(Costmap3DConfig &config, uint32_t level)
+{
+  geometry_msgs::Point min, max;
+
+  layered_costmap_3d_.setBounds(config.map_z_min, config.map_z_max);
+
+  footprint_3d_padding_ = config.footprint_3d_padding;
+
+  publishFootprint();
+}
+
+void Costmap3DROS::updateMap()
+{
+  std::lock_guard<std::mutex> initialize_lock(initialized_mutex_);
+
+  if (initialized_ && !isPaused())
+  {
+    // First update the 3D map.
+    // We update 3D first, in case any 3D layers need to affect 2D layers.
+    // Get global pose of robot
+    tf::Stamped < tf::Pose > pose;
+    if (getRobotPose (pose))
+    {
+      geometry_msgs::Pose pose_msg;
+      tf::poseTFToMsg(pose, pose_msg);
+      layered_costmap_3d_.updateMap(pose_msg);
+    }
+
+    // Now update the 2D map
+    super::updateMap();
+  }
+}
+
+void Costmap3DROS::start()
+{
+  // check if we're stopped or just paused
+  if (isStopped())
+  {
+    layered_costmap_3d_.activate();
+  }
+
+  super::start();
+}
+
+void Costmap3DROS::stop()
+{
+  super::stop();
+  layered_costmap_3d_.deactivate();
+}
+
+void Costmap3DROS::resetLayers()
+{
+  layered_costmap_3d_.reset();
+  super::resetLayers();
+}
+
+std::shared_ptr<Costmap3DQuery> Costmap3DROS::getBufferedQuery(
+        const std::string& footprint_mesh_resource,
+        double padding)
+{
+  const std::string& query_mesh(getFootprintMeshResource(footprint_mesh_resource));
+  padding = getFootprintPadding(padding);
+  std::lock_guard<LayeredCostmap3D> lock(layered_costmap_3d_);
+  return std::shared_ptr<Costmap3DQuery>(new Costmap3DQuery(layered_costmap_3d_.getCostmap3D(), query_mesh, padding));
+}
+
+std::shared_ptr<Costmap3DQuery> Costmap3DROS::getAssociatedQuery(
+        const std::string& footprint_mesh_resource,
+        double padding)
+{
+  const std::string& query_mesh(getFootprintMeshResource(footprint_mesh_resource));
+  padding = getFootprintPadding(padding);
+  std::lock_guard<LayeredCostmap3D> lock(layered_costmap_3d_);
+  return std::shared_ptr<Costmap3DQuery>(new Costmap3DQuery(&layered_costmap_3d_, query_mesh, padding));
+}
+
+std::set<std::string> Costmap3DROS::getLayerNames()
+{
+  // Begin with any 2D layers
+  std::set<std::string> plugin_names(super::getLayerNames());
+
+  std::lock_guard<LayeredCostmap3D> lock(layered_costmap_3d_);
+
+  // Add the 3D layers to the list
+  for (auto plugin : layered_costmap_3d_.getPlugins())
+  {
+    plugin_names.insert(plugin->getName());
+  }
+
+  return plugin_names;
+}
+
+void Costmap3DROS::resetBoundingBox(geometry_msgs::Point min, geometry_msgs::Point max, const std::set<std::string>& layers)
+{
+  {
+    // Its not OK to hold the lock while calling super::resetBoundingBox even
+    // though the lock is recursive because it will break the condition variable
+    // wait.
+    std::lock_guard<LayeredCostmap3D> lock(layered_costmap_3d_);
+
+    // Reset all 3D layers first, then 2D layers, because Costmap2DROS
+    // resetBoundingBox waits for the next update
+    for (auto plugin : layered_costmap_3d_.getPlugins())
+    {
+      // Only reset layers that are in the layer set
+      // Match either the whole layer name, or just the final name after the
+      // final '/'.
+      const std::string& plugin_full_name(plugin->getName());
+      std::string plugin_last_name_only;
+      int slash = plugin_full_name.rfind('/');
+      if( slash != std::string::npos )
+      {
+        plugin_last_name_only = plugin_full_name.substr(slash+1);
+      }
+      ROS_INFO_STREAM("resetBoundingBox consider 3D layer: " << plugin_full_name <<
+                      " last name: " << plugin_last_name_only);
+      if (layers.find(plugin_full_name) != layers.end()
+          || plugin_last_name_only.size() > 0 && layers.find(plugin_last_name_only) != layers.end())
+      {
+        ROS_INFO_STREAM("resetBoundingBox 3D layer " << plugin->getName());
+        plugin->resetBoundingBox(min, max);
+      }
+    }
+  }
+
+  super::resetBoundingBox(min, max, layers);
+}
+
+const std::string& Costmap3DROS::getFootprintMeshResource(const std::string& alt_mesh)
+{
+  // TODO: need to verify that the alt file actually exists
+  if (alt_mesh.empty())
+  {
+    return footprint_mesh_resource_;
+  }
+  return alt_mesh;
+}
+
+double Costmap3DROS::getFootprintPadding(double alt_padding)
+{
+  if (!std::isfinite(alt_padding))
+  {
+    return footprint_3d_padding_;
+  }
+  return alt_padding;
+}
+
+void Costmap3DROS::publishFootprint()
+{
+  // TODO: publish a footprint with the padding applied
+  visualization_msgs::Marker marker;
+  marker.header.frame_id = getBaseFrameID();
+  marker.header.stamp = ros::Time();
+  marker.type = visualization_msgs::Marker::MESH_RESOURCE;
+  marker.action = visualization_msgs::Marker::ADD;
+  marker.pose.position.x = 0.0;
+  marker.pose.position.y = 0.0;
+  marker.pose.position.z = 0.0;
+  marker.pose.orientation.x = 0.0;
+  marker.pose.orientation.y = 0.0;
+  marker.pose.orientation.z = 0.0;
+  marker.pose.orientation.w = 1.0;
+  marker.scale.x = 1;
+  marker.scale.y = 1;
+  marker.scale.z = 1;
+  marker.color.a = 0.5;
+  marker.color.r = 0.5;
+  marker.color.g = 0.5;
+  marker.color.b = 0.5;
+  marker.frame_locked = true;
+  marker.mesh_resource = footprint_mesh_resource_;
+  footprint_pub_.publish(marker);
+}
+
+std::shared_ptr<Costmap3DQuery> Costmap3DROS::getQuery(const std::string& footprint_mesh_resource, double padding)
+{
+  const std::string& query_mesh(getFootprintMeshResource(footprint_mesh_resource));
+  padding = getFootprintPadding(padding);
+  auto query_pair = std::make_pair(query_mesh, padding);
+  auto query_it = query_map_.find(query_pair);
+  if (query_it == query_map_.end())
+  {
+    // Query object does not exist, create it and add it to the map
+    std::shared_ptr<Costmap3DQuery> query;
+    query.reset(new Costmap3DQuery(&layered_costmap_3d_, query_mesh, padding));
+    query_it = query_map_.insert(std::make_pair(query_pair, query)).first;
+  }
+  return query_it->second;
+}
+
+double Costmap3DROS::footprintCost(geometry_msgs::Pose pose,
+                                   const std::string& footprint_mesh_resource,
+                                   double padding)
+{
+  return getQuery(footprint_mesh_resource, padding)->footprintCost(pose);
+}
+
+bool Costmap3DROS::footprintCollision(geometry_msgs::Pose pose,
+                                      const std::string& footprint_mesh_resource,
+                                      double padding)
+{
+  return getQuery(footprint_mesh_resource, padding)->footprintCollision(pose);
+}
+
+double Costmap3DROS::footprintDistance(geometry_msgs::Pose pose,
+                                       const std::string& footprint_mesh_resource,
+                                       double padding)
+{
+  return getQuery(footprint_mesh_resource, padding)->footprintDistance(pose);
+}
+
+double Costmap3DROS::footprintSignedDistance(geometry_msgs::Pose pose,
+                                             const std::string& footprint_mesh_resource,
+                                             double padding)
+{
+  return getQuery(footprint_mesh_resource, padding)->footprintSignedDistance(pose);
+}
+
+void Costmap3DROS::getPlanCost3DActionCallback(
+    const actionlib::SimpleActionServer<GetPlanCost3DAction>::GoalConstPtr& goal)
+{
+  GetPlanCost3DResult result;
+  processPlanCost3D(*goal, result);
+  get_plan_cost_action_srv_.setSucceeded(result);
+}
+
+bool Costmap3DROS::getPlanCost3DServiceCallback(
+    GetPlanCost3DService::Request& request,
+    GetPlanCost3DService::Response& response)
+{
+  processPlanCost3D(request, response);
+  return true;
+}
+
+template <typename RequestType, typename ResponseType>
+void Costmap3DROS::processPlanCost3D(RequestType& request, ResponseType& response)
+{
+  // Be sure the costmap is locked while querying, if necessary.
+  std::unique_lock <LayeredCostmap3D> lock(layered_costmap_3d_, std::defer_lock);
+  std::shared_ptr<Costmap3DQuery> query;
+
+#if (COSTMAP_3D_ROS_AUTO_PROFILE_QUERY) > 0
+  ROS_INFO("Starting getPlanCost3DServiceCallback");
+  ros::Time start_time = ros::Time::now();
+  kill(getpid(), 12);
+#endif
+
+  if (request.buffered)
+  {
+    // Buffered request, getBufferedQuery gets the lock directly
+    query = getBufferedQuery(request.footprint_mesh_resource, request.padding);
+  }
+  else
+  {
+    // Unbuffered request, must hold the lock for the duration.
+    lock.lock();
+    query = getQuery(request.footprint_mesh_resource, request.padding);
+  }
+
+  if (request.cost_query_mode == GetPlanCost3DService::Request::COST_QUERY_MODE_DISTANCE ||
+      request.cost_query_mode == GetPlanCost3DService::Request::COST_QUERY_MODE_EXACT_SIGNED_DISTANCE)
+  {
+    response.cost = std::numeric_limits<double>::max();
+  }
+  else
+  {
+    response.cost = 0.0;
+  }
+
+  response.pose_costs.reserve(request.poses.size());
+  response.lethal_indices.reserve(request.poses.size());
+  for (int i = 0; i < request.poses.size(); ++i)
+  {
+    bool collision = false;
+    // NOTE: Costmap3D does not support time (its not a 4D costmap!) so ignore the stamp.
+    const auto pose = request.poses[i].pose;
+    double pose_cost = -1.0;
+    // Warn if the frame doesn't match. We currently don't transform the poses.
+    if (request.poses[i].header.frame_id != layered_costmap_3d_.getGlobalFrameID())
+    {
+      ROS_WARN_STREAM_THROTTLE(1.0, "Costmap3DROS::getPlanCost3DServiceCallback expects poses in frame " <<
+                               layered_costmap_3d_.getGlobalFrameID() << " but pose was in frame " <<
+                               request.poses[i].header.frame_id);
+      // Leave the pose_cost lethal
+    }
+    else if (request.cost_query_mode == GetPlanCost3DService::Request::COST_QUERY_MODE_COLLISION_ONLY)
+    {
+      pose_cost = query->footprintCollision(pose) ? -1.0 : 0.0;
+    }
+    else if (request.cost_query_mode == GetPlanCost3DService::Request::COST_QUERY_MODE_DISTANCE)
+    {
+      pose_cost = query->footprintDistance(pose);
+    }
+    else if (request.cost_query_mode == GetPlanCost3DService::Request::COST_QUERY_MODE_EXACT_SIGNED_DISTANCE)
+    {
+      pose_cost = query->footprintSignedDistance(pose);
+    }
+    else
+    {
+      pose_cost = query->footprintCost(pose);
+    }
+    // negative is a collision
+    if (pose_cost < 0.0)
+    {
+      collision = true;
+    }
+    if (request.cost_query_mode == GetPlanCost3DService::Request::COST_QUERY_MODE_DISTANCE ||
+        request.cost_query_mode == GetPlanCost3DService::Request::COST_QUERY_MODE_EXACT_SIGNED_DISTANCE)
+    {
+      // in distance mode, the cost is the minimum distance across all poses
+      response.cost = std::min(response.cost, pose_cost);
+    }
+    else
+    {
+      // in collision or cost mode, plan cost will either be negative if there is a collision
+      // or the aggregate non-lethal cost.
+      if (collision)
+      {
+        if (response.cost >= 0.0)
+        {
+          // this pose is in collision, but the plan hasn't seen a collision yet.
+          // reset the cost to this pose's cost
+          response.cost = pose_cost;
+        }
+        else
+        {
+          // otherwise, add the lethal pose_cost to the cost (making it more negative)
+          response.cost += pose_cost;
+        }
+      }
+      else
+      {
+        if (response.cost >= 0.0)
+        {
+          // not in collision, plan not in collision, add the cost
+          response.cost += pose_cost;
+        }
+        // don't add the non-lethal cost to a lethal plan
+      }
+    }
+    response.pose_costs.push_back(pose_cost);
+    if (collision)
+    {
+      response.lethal_indices.push_back(i);
+      if (request.lazy)
+      {
+        break;
+      }
+    }
+  }
+
+#if (COSTMAP_3D_ROS_AUTO_PROFILE_QUERY) > 0
+  kill(getpid(), 12);
+  ROS_INFO_STREAM("Finished getting " << request.poses.size() << " poses in " <<
+                  (ros::Time::now() - start_time).toSec() << " seconds.");
+#endif
+}
+
+}  // namespace costmap_3d

--- a/costmap_3d/src/costmap_layer_3d.cpp
+++ b/costmap_3d/src/costmap_layer_3d.cpp
@@ -1,0 +1,314 @@
+/*********************************************************************
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Badger Technologies LLC
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: C. Andy Martin
+ *********************************************************************/
+#include <costmap_3d/costmap_layer_3d.h>
+#include <costmap_3d/GenericPluginConfig.h>
+
+namespace costmap_3d
+{
+
+CostmapLayer3D::CostmapLayer3D() : super()
+{
+}
+
+CostmapLayer3D::~CostmapLayer3D()
+{
+}
+
+void CostmapLayer3D::updateBounds(const geometry_msgs::Pose robot_pose,
+                                  const geometry_msgs::Point& rolled_min,
+                                  const geometry_msgs::Point& rolled_max,
+                                  Costmap3D* bounds_map)
+{
+  if (costmap_)
+  {
+    // Don't track deleting out-of-bounds nodes.
+    // Note: if we ever publish a debug map, we should probably track them for
+    // efficient delta publishing.
+    costmap_->deleteAABB(toOctomapPoint(rolled_min),
+                         toOctomapPoint(rolled_max),
+                         true);
+
+  }
+  if (changed_cells_)
+  {
+    bounds_map->setTreeValues(changed_cells_.get(), true, false);
+
+    // If we were to publish a map for debug, it would be here.
+
+    // Clear out changed cells now that we are finished with it.
+    changed_cells_->clear();
+  }
+}
+
+void CostmapLayer3D::updateCosts(const Costmap3D& bounds_map, Costmap3D* master_map)
+{
+  if (costmap_ && enabled_)
+  {
+    switch (combination_method_)
+    {
+      case GenericPlugin_Overwrite:
+        master_map->setTreeValues(costmap_.get(), &bounds_map, false, false);
+        break;
+      case GenericPlugin_Maximum:
+        master_map->setTreeValues(costmap_.get(), &bounds_map, true, false);
+        break;
+      default:
+      case GenericPlugin_Nothing:
+        // In case this was a mistake, give info once that we are using NOTHING
+        ROS_INFO_STREAM_ONCE("costmap layer '" << name_ << "' combination method NOTHING");
+        break;
+    }
+  }
+}
+
+#if 0
+void CostmapLayer3D::initialize(LayeredCostmap3D* parent, std::string name, tf::TransformListener *tf)
+{
+  super::initialize(parent, name, tf);
+  // Note that the master costmap's resolution is not set yet.
+  // Our setResolution method will be called later once it is set.
+}
+#endif
+
+void CostmapLayer3D::deactivate()
+{
+  std::lock_guard<Layer3D> lock(*this);
+
+  // Ensure the next costmap update will not have any information stored in
+  // this layer.
+  if (costmap_) touch(*costmap_);
+}
+
+void CostmapLayer3D::activate()
+{
+  std::lock_guard<Layer3D> lock(*this);
+
+  // Ensure the next costmap update will have any information stored in
+  // this layer.
+  if (costmap_) touch(*costmap_);
+}
+
+void CostmapLayer3D::reset()
+{
+  std::lock_guard<Layer3D> lock(*this);
+  if (costmap_)
+  {
+    // Ensure the next costmap update will not have any old information from
+    // this layer.
+    touch(*costmap_);
+    costmap_->clear();
+  }
+}
+
+void CostmapLayer3D::resetBoundingBox(Costmap3DIndex min, Costmap3DIndex max)
+{
+  std::lock_guard<Layer3D> lock(*this);
+  if (costmap_ && changed_cells_)
+  {
+    resetBoundingBoxUnlocked(min, max);
+  }
+};
+
+void CostmapLayer3D::resetBoundingBox(geometry_msgs::Point min_point, geometry_msgs::Point max_point)
+{
+  std::lock_guard<Layer3D> lock(*this);
+  if (costmap_ && changed_cells_)
+  {
+    Costmap3DIndex min_key, max_key;
+    costmap_->coordToKeyClamped(toOctomapPoint(min_point), min_key);
+    costmap_->coordToKeyClamped(toOctomapPoint(max_point), max_key);
+    resetBoundingBoxUnlocked(min_key, max_key);
+  }
+}
+
+void CostmapLayer3D::matchSize(const geometry_msgs::Point& min, const geometry_msgs::Point& max, double resolution)
+{
+  std::lock_guard<Layer3D> lock(*this);
+  if ((!costmap_ && resolution > 0.0) || (costmap_ && resolution != costmap_->getResolution()))
+  {
+    changed_cells_.reset(new Costmap3D(resolution));
+    costmap_.reset(new Costmap3D(resolution));
+  }
+  // If a child class octomap has limits that can be set, such as the one in
+  // OctomapServer, they could be set here
+}
+
+void CostmapLayer3D::resetBoundingBoxUnlocked(Costmap3DIndex min, Costmap3DIndex max)
+{
+  // Delete the AABB from the tree, and add any deleted leafs to the changed cells.
+  costmap_->deleteAABB(min, max, false,
+                       std::bind([](Costmap3D* tree, const Costmap3DIndex& key, unsigned int depth)
+                                 {tree->setNodeValueAtDepth(key, depth, LETHAL);},
+                                 changed_cells_.get(),
+                                 std::placeholders::_3,
+                                 std::placeholders::_4));
+}
+
+void CostmapLayer3D::touch(const octomap::OcTree& touch_map)
+{
+  if (changed_cells_ && enabled_)
+  {
+    changed_cells_->setTreeValues(&touch_map, false, false,
+                                  [](const Costmap3D::NodeType*, Costmap3D::NodeType* node, bool, const octomap::OcTreeKey&, unsigned int)
+                                  {node->setValue(LETHAL);});
+  }
+}
+
+void CostmapLayer3D::touch(const Costmap3DIndex& key)
+{
+  touchKeyAtDepth(key);
+}
+
+void CostmapLayer3D::touchKeyAtDepth(const octomap::OcTreeKey& key, unsigned int depth)
+{
+  if (changed_cells_)
+  {
+    changed_cells_->setNodeValueAtDepth(key, depth, LETHAL);
+  }
+}
+
+void CostmapLayer3D::updateCells(const octomap::OcTree& value_map, const octomap::OcTree& bounds_map,
+                                 Cost occupied_threshold)
+{
+  if (costmap_)
+  {
+    // Erase the map in the bounds region then set to either LETHAL or FREE
+    // based on the given threshold applied to the value map values.
+    costmap_->setTreeValues(&value_map, &bounds_map, false, true,
+                            std::bind([](Cost thresh, const Costmap3D::NodeType* value_node, Costmap3D::NodeType* node)
+                                      {node->setValue(value_node->getValue() >= thresh ? LETHAL : FREE);},
+                                      occupied_threshold,
+                                      std::placeholders::_1,
+                                      std::placeholders::_2));
+  }
+  touch(bounds_map);
+}
+
+void CostmapLayer3D::updateCell(const geometry_msgs::Point& point, bool mark)
+{
+  Cost cost = mark ? LETHAL : FREE;
+  setCellCost(point, cost);
+}
+
+void CostmapLayer3D::updateCell(const octomap::OcTreeKey& key, bool mark)
+{
+  Cost cost = mark ? LETHAL : FREE;
+  setCellCost(key, cost);
+}
+
+void CostmapLayer3D::markCell(const geometry_msgs::Point& point)
+{
+  setCellCost(point, LETHAL);
+}
+
+void CostmapLayer3D::markCell(const octomap::OcTreeKey& key)
+{
+  setCellCost(key, LETHAL);
+}
+
+void CostmapLayer3D::clearCell(const geometry_msgs::Point& point)
+{
+  setCellCost(point, FREE);
+}
+
+void CostmapLayer3D::clearCell(const octomap::OcTreeKey& key)
+{
+  setCellCost(key, FREE);
+}
+
+void CostmapLayer3D::markAndClearCells(const Costmap3D& map)
+{
+  if (costmap_)
+  {
+    costmap_->setTreeValues(&map);
+    touch(map);
+  }
+}
+
+void CostmapLayer3D::eraseCell(const geometry_msgs::Point& point)
+{
+  setCellCost(point, UNKNOWN);
+}
+
+void CostmapLayer3D::eraseCell(const octomap::OcTreeKey& key)
+{
+  setCellCost(key, UNKNOWN);
+}
+
+void CostmapLayer3D::eraseCells(const Costmap3D& map)
+{
+  if (costmap_)
+  {
+    costmap_->setTreeValues(NULL, &map, false, true);
+    touch(map);
+  }
+}
+
+void CostmapLayer3D::setCellCostAtDepth(const octomap::OcTreeKey& key, Cost cost, unsigned int depth)
+{
+  if (costmap_)
+  {
+    if (cost >= FREE)
+    {
+      costmap_->setNodeValueAtDepth(key, depth, cost);
+    }
+    else
+    {
+      // A cost not greater or equal to free is unknown (either too negative
+      // or its a NAN). Don't bother saving unknown, just delete it.
+      costmap_->deleteNode(key, depth);
+    }
+    touchKeyAtDepth(key, depth);
+  }
+}
+
+void CostmapLayer3D::setCellCost(const octomap::OcTreeKey& key, Cost cost)
+{
+  setCellCostAtDepth(key, cost);
+}
+
+void CostmapLayer3D::setCellCost(const geometry_msgs::Point& point, Cost cost)
+{
+  if (costmap_)
+  {
+    Costmap3DIndex key;
+    if (costmap_->coordToKeyChecked(toOctomapPoint(point), key))
+      setCellCost(key, cost);
+  }
+}
+
+}  // namespace costmap_3d

--- a/costmap_3d/src/layer_3d.cpp
+++ b/costmap_3d/src/layer_3d.cpp
@@ -1,0 +1,73 @@
+/*********************************************************************
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Badger Technologies LLC
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: C. Andy Martin
+ *********************************************************************/
+#include <costmap_3d/layer_3d.h>
+
+namespace costmap_3d
+{
+
+Layer3D::Layer3D() {}
+
+Layer3D::~Layer3D() {}
+
+void Layer3D::initialize(LayeredCostmap3D* parent, std::string name, tf::TransformListener *tf)
+{
+  layered_costmap_3d_ = parent;
+  name_ = name;
+  tf_ = tf;
+}
+
+bool Layer3D::isCurrent() const
+{
+  return current_;
+}
+
+std::string Layer3D::getName() const
+{
+  return name_;
+}
+
+void Layer3D::lock()
+{
+  mutex_.lock();
+}
+
+void Layer3D::unlock()
+{
+  mutex_.unlock();
+}
+
+}  // namespace costmap_3d

--- a/costmap_3d/src/layered_costmap_3d.cpp
+++ b/costmap_3d/src/layered_costmap_3d.cpp
@@ -1,0 +1,362 @@
+/*********************************************************************
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Badger Technologies LLC
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: C. Andy Martin
+ *********************************************************************/
+#include <costmap_3d/layered_costmap_3d.h>
+
+namespace costmap_3d
+{
+
+LayeredCostmap3D::LayeredCostmap3D(costmap_2d::LayeredCostmap* layered_costmap_2d)
+    : lock_layers_(this),
+      layered_costmap_2d_(layered_costmap_2d),
+      size_changed_(false),
+      resolution_(0.0)
+{
+  min_point_.x = -std::numeric_limits<double>::max();
+  min_point_.y = -std::numeric_limits<double>::max();
+  min_point_.z = -std::numeric_limits<double>::max();
+  max_point_.x = std::numeric_limits<double>::max();
+  max_point_.y = std::numeric_limits<double>::max();
+  max_point_.z = std::numeric_limits<double>::max();
+}
+
+LayeredCostmap3D::~LayeredCostmap3D()
+{
+}
+
+void LayeredCostmap3D::updateMap(geometry_msgs::Pose robot_pose)
+{
+  // Lock the master costmap
+  std::lock_guard<LayeredCostmap3D> lock(*this);
+
+  matchBoundsAndResolution();
+
+  num_updates_++;
+
+  if (!costmap_)
+  {
+    // We don't have a costmap to update!
+    return;
+  }
+
+  Costmap3D bounds_map(costmap_->getResolution());
+
+  // Calculate the current aabb (most useful for rolling maps).
+  octomap::point3d aabb_min = toOctomapPoint(min_point_);
+  octomap::point3d aabb_max = toOctomapPoint(max_point_);
+  if (isRolling())
+  {
+    // Adjust the x/y based on the x/y of the robot's pose, as a rolling map
+    // stays centered on the robot base in x/y (but not z).
+    float robot_x = (float)robot_pose.position.x;
+    float robot_y = (float)robot_pose.position.y;
+    float aabb_width = aabb_max.x() - aabb_min.x();
+    float aabb_height = aabb_max.y() - aabb_min.y();
+    aabb_min.x() += robot_x - aabb_width/2.0f;
+    aabb_min.y() += robot_y - aabb_height/2.0f;
+    aabb_max.x() += robot_x - aabb_width/2.0f;
+    aabb_max.y() += robot_y - aabb_height/2.0f;
+  }
+  const geometry_msgs::Point min_msg(fromOctomapPoint(aabb_min));
+  const geometry_msgs::Point max_msg(fromOctomapPoint(aabb_max));
+
+  ROS_DEBUG_STREAM("LayeredCostmap3D: updateMap: min point " << min_msg << " max point " << max_msg);
+
+  {
+    // lock all the costmap layers
+    std::lock_guard<LockLayers> layers_lock(lock_layers_);
+
+    for (auto plugin : plugins_)
+    {
+      plugin->updateBounds(robot_pose, min_msg, max_msg, &bounds_map);
+    }
+
+    if (size_changed_)
+    {
+      // Treat the entire map as changed to pull in any data that is
+      // immediately ready in the plugins. Some plugins may represent data in
+      // a way that is resolution-independent and may already have data on the
+      // next updateCosts call. We could use a NULL value in setTreeValues for
+      // the bounds map, but we must call updateBounds on every cycle to
+      // preserve the API to the plugins, and must pass a valid bounds map
+      // pointer, so make the bounds map represent the entire universe.
+      bounds_map.setNodeValueAtDepth(Costmap3DIndex(), 0, LETHAL);
+    }
+
+    // Remove any out-of-bounds entries from the bounds map.
+    // This will prevent layers from copying back any data that is
+    // out-of-bounds below.
+    bounds_map.deleteAABB(aabb_min, aabb_max, true);
+
+    // Delete the current cells that are being updated.
+    costmap_->setTreeValues(NULL, &bounds_map, false, true);
+
+    // Update the costs of the regions of interest in the bounds_map
+    for (auto plugin : plugins_)
+    {
+      plugin->updateCosts(bounds_map, costmap_.get());
+    }
+  }
+
+  // Delete any out-of-bounds information from our costmap.
+  // Do this after updateCosts to ensure no out-of-bounds information remains
+  // from an errant layer that ignores the bounds map.
+  // Set any cells that are deleted in the bounds map to use when publishing the update.
+  costmap_->deleteAABB(aabb_min, aabb_max, true,
+                       std::bind([](Costmap3D* tree, const Costmap3DIndex& key, unsigned int depth)
+                                 {tree->setNodeValueAtDepth(key, depth, LETHAL);},
+                                 &bounds_map,
+                                 std::placeholders::_3,
+                                 std::placeholders::_4));
+
+  if (size_changed_)
+  {
+    // Any old values that were deleted during the size change will get
+    // stuck if we do not publish a full map here. Just use the univeral
+    // bounds for the bounds_map if the size has changed.
+    bounds_map.setNodeValueAtDepth(Costmap3DIndex(), 0, LETHAL);
+    size_changed_ = false;
+  }
+
+  // Calculate the update to publish
+  Costmap3D map_delta(costmap_->getResolution());
+  map_delta.setTreeValues(costmap_.get(), &bounds_map, false, false);
+
+  std::lock_guard<std::mutex> callback_lock(update_complete_callbacks_mutex_);
+  for (auto cb : update_complete_callbacks_)
+  {
+    cb.second(this, map_delta, bounds_map);
+  }
+}
+
+void LayeredCostmap3D::registerUpdateCompleteCallback(const std::string callback_id, UpdateCompleteCallback cb)
+{
+  std::lock_guard<std::mutex> callback_lock(update_complete_callbacks_mutex_);
+  update_complete_callbacks_[callback_id] = cb;
+}
+
+void LayeredCostmap3D::unregisterUpdateCompleteCallback(const std::string callback_id)
+{
+  std::lock_guard<std::mutex> callback_lock(update_complete_callbacks_mutex_);
+  auto it = update_complete_callbacks_.find(callback_id);
+  if (it != update_complete_callbacks_.end())
+  {
+    update_complete_callbacks_.erase(it);
+  }
+}
+
+void LayeredCostmap3D::reset()
+{
+  std::lock_guard<LayeredCostmap3D> lock(*this);
+  // Force a full publish on the next cycle
+  size_changed_ = true;
+  costmap_->clear();
+
+  for (auto plugin : plugins_)
+  {
+    plugin->reset();
+  }
+}
+
+void LayeredCostmap3D::activate()
+{
+  for (auto plugin : plugins_)
+  {
+    plugin->activate();
+  }
+}
+
+void LayeredCostmap3D::deactivate()
+{
+  for (auto plugin : plugins_)
+  {
+    plugin->deactivate();
+  }
+}
+
+bool LayeredCostmap3D::isCurrent() const
+{
+  for (auto plugin : plugins_)
+  {
+    if (!plugin->isCurrent())
+    {
+      ROS_INFO_STREAM_THROTTLE(1.0, "LayeredCostmap3D layer " << plugin->getName() << " is not current");
+      return false;
+    }
+  }
+  return true;
+}
+
+Costmap3DConstPtr LayeredCostmap3D::getCostmap3D() const
+{
+  return costmap_;
+}
+
+bool LayeredCostmap3D::isRolling() const
+{
+  return layered_costmap_2d_->isRolling();
+}
+
+const std::vector<boost::shared_ptr<Layer3D>>& LayeredCostmap3D::getPlugins()
+{
+  return plugins_;
+}
+
+void LayeredCostmap3D::addPlugin(boost::shared_ptr<Layer3D> plugin)
+{
+  std::lock_guard<LayeredCostmap3D> lock(*this);
+  plugins_.push_back(plugin);
+}
+
+void LayeredCostmap3D::lock()
+{
+  // To synchronize correctly with planners, we must use the same mutex
+  // they do, which is the master 2D costmap lock.
+  layered_costmap_2d_->getCostmap()->getMutex()->lock();
+}
+
+void LayeredCostmap3D::unlock()
+{
+  layered_costmap_2d_->getCostmap()->getMutex()->unlock();
+}
+
+double LayeredCostmap3D::getResolution() const
+{
+  return resolution_;
+}
+
+void LayeredCostmap3D::getBounds(geometry_msgs::Point* min, geometry_msgs::Point* max)
+{
+  // keep the view of min/max consistent
+  std::lock_guard<LayeredCostmap3D> lock(*this);
+  *min = min_point_;
+  *max = max_point_;
+}
+
+void LayeredCostmap3D::setBounds(double min_z, double max_z)
+{
+  std::lock_guard<LayeredCostmap3D> lock(*this);
+  matchBoundsAndResolution(min_z, max_z);
+}
+
+void LayeredCostmap3D::matchBoundsAndResolution()
+{
+  // Just call matchBounds w/ the current Z bounds
+  matchBoundsAndResolution(min_point_.z, max_point_.z);
+}
+
+void LayeredCostmap3D::matchBoundsAndResolution(double min_z, double max_z)
+{
+  bool change_size = false;
+  geometry_msgs::Point min, max;
+  min.z = min_z;
+  max.z = max_z;
+  // Get the x/y values from the 2D costmap
+  if (isRolling())
+  {
+    // If we are rolling, set the origin to zero, as we will shift the limits
+    // based on the base position ourselves in updateMap, since the octomap is
+    // always originated at (0, 0, 0).
+    min.x = 0.0;
+    min.y = 0.0;
+  }
+  else
+  {
+    // If we are not rolling, use the 2D origin as the minimum.
+    min.x = layered_costmap_2d_->getCostmap()->getOriginX();
+    min.y = layered_costmap_2d_->getCostmap()->getOriginY();
+  }
+  max.x = min.x + layered_costmap_2d_->getCostmap()->getSizeInMetersX();
+  max.y = min.y + layered_costmap_2d_->getCostmap()->getSizeInMetersY();
+  if (min.x != min_point_.x ||
+      min.y != min_point_.y ||
+      min.z != min_point_.z ||
+      max.x != max_point_.x ||
+      max.y != max_point_.y ||
+      max.z != max_point_.z)
+  {
+    ROS_DEBUG_STREAM("LayeredCostmap3D: min point " << min << " max point " << max);
+    min_point_ = min;
+    max_point_ = max;
+    change_size = true;
+  }
+  double resolution = layered_costmap_2d_->getCostmap()->getResolution();
+  if (resolution > 0.0 && resolution != resolution_)
+  {
+    resolution_ = resolution;
+    change_size = true;
+  }
+  if (change_size)
+  {
+    sizeChange();
+  }
+}
+
+void LayeredCostmap3D::sizeChange()
+{
+  size_changed_ = true;
+  if (resolution_ > 0.0)
+  {
+    costmap_.reset(new Costmap3D(resolution_));
+  }
+  for (auto plugin : plugins_)
+  {
+    plugin->matchSize(min_point_, max_point_, resolution_);
+  }
+}
+
+LayeredCostmap3D::LockLayers::LockLayers(LayeredCostmap3D* layered_costmap_3d)
+  : layered_costmap_3d_(layered_costmap_3d)
+{
+}
+
+void LayeredCostmap3D::LockLayers::lock()
+{
+  for (auto plugin : layered_costmap_3d_->getPlugins())
+  {
+    plugin->lock();
+  }
+}
+
+void LayeredCostmap3D::LockLayers::unlock()
+{
+  for (auto plugin : layered_costmap_3d_->getPlugins())
+  {
+    plugin->unlock();
+  }
+}
+
+}  // namespace costmap_3d

--- a/costmap_3d/srv/GetPlanCost3DService.srv
+++ b/costmap_3d/srv/GetPlanCost3DService.srv
@@ -1,0 +1,53 @@
+# Get the cost of a plan in the 3D costmap.
+# The first two fields are identical to nav_msgs/Path
+Header header
+geometry_msgs/PoseStamped[] poses
+
+# If true, stop as soon as a lethal pose is found.
+# Poses are processed in order, and when a lethal pose is found
+# no further processing is done.
+bool lazy
+
+# If true, run this query on a copy of the costmap, leaving it unlocked
+# after copy. If false, run directly on the master costmap, leaving it locked
+# for the duration of the query.
+bool buffered
+
+# Return costs of each pose as normal
+uint8 COST_QUERY_MODE_COST=0
+# Do not find actual costs, just binary collision information
+uint8 COST_QUERY_MODE_COLLISION_ONLY=1
+# Do not find actual costs, find distances instead
+uint8 COST_QUERY_MODE_DISTANCE=2
+# Do not find actual costs, find exact signed distances instead
+uint8 COST_QUERY_MODE_EXACT_SIGNED_DISTANCE=3
+# Set to one of the above COST_QUERY_MODE_* to control query mode.
+# The default is COST_QUERY_MODE_COST.
+uint8 cost_query_mode
+
+# An alternative footprint_mesh_resource to use (in base_footprint frame)
+# If empty, the default stored in the costmap will be used.
+string footprint_mesh_resource
+
+# How much padding (in meters) to grow the footprint mesh.
+# (negative numbers will shrink the mesh).
+# 0.0 means no padding.
+# NaN means use the default value from the costmap.
+# To precisely control padding, use an alternate mesh, as the generated mesh
+# may pad in a naive way.
+float32 padding
+---
+# The aggregate cost value across the poses.
+# A negative cost value indicates collision.
+# A cost value of 0.0 means no cost.
+# A postive cost value indicates non-zero, yet non-lethal cost.
+# When running in one of the distance modes, the plan_cost will be the minimum
+# distance across all the poses. Note that all forms of distance check will return
+# a negative distance for a collision, but only in the exact signed mode will
+# the negative value be an exact signed distance.
+float64 cost
+# The cost of each pose.
+# When running in one of the distance modes, the "cost" will instead be the
+# distance to the nearest obstacle in meters.
+float64[] pose_costs
+uint32[] lethal_indices


### PR DESCRIPTION
The main body of this PR is adding a new costmap-3d package, which provides a 3D layered costmap based on octomaps. (Important Note: currently the badger-develop branch of octomap is required). The Costmap3DROS specializes Costmap2DROS to provide smooth backwards comparability. In order for that to work, the Costmap2DROS API was extended and ABI was broken (due to adding virtual keywords).

Since the Costmap3DROS is a Costmap2DROS, it has a 2D costmap associated with it. By default, this costmap will be empty. However, there is a pair of layer plugins which can be used to forward a flattened version of the 3D costmap to the corresponding 2D costmap, allowing easy migration into 3D navigation (so, for instance, some planners can be made to use the 3D costmap, while others continue to use the 2D costmap).

Several example costmap 3d plugins are provided, in addition to the previously mentioned 3D=>2D conversion layers. An octomap server layer is provided which subscribes to octomap updates from an octomap server. The corresponding octomap server can integrated many different sources of data (point clouds, laser scans). Also, a point cloud layer is provided which copies the last point cloud received into a costmap layer.

In addition to the 3D maps, the Costmap3DROS provides a direct querying interface in contrast to the 2D costmap. This query interface uses the badger-develop branch of FCL to perform queries against a robot mesh and the current costmap state. Four types of queries are provided, collision, cost, distance and signed distance, although not all are yet implemented.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/navigation/9)
<!-- Reviewable:end -->
