### PR TITLE
Costmap 3D: Support 32 bit keys, variable octomap depth, coords as doubles, new octomap msgs

### DIFF
--- a/costmap_3d/include/costmap_3d/costmap_3d_ros.h
+++ b/costmap_3d/include/costmap_3d/costmap_3d_ros.h
@@ -90,10 +90,7 @@ public:
   virtual void resetLayers();
 
   /** @brief Returns true if all layers have current sensor data. */
-  virtual bool isCurrent()
-  {
-    return super::isCurrent() && layered_costmap_3d_.isCurrent();
-  }
+  virtual bool isCurrent();
 
   /* Unlike Costmap2D, provide no interface to the 3D layered costmap internals.
    * Instead provide specific interfaces to clear 3D layers and get 3D collision

--- a/costmap_3d/include/costmap_3d/costmap_layer_3d.h
+++ b/costmap_3d/include/costmap_3d/costmap_layer_3d.h
@@ -136,7 +136,18 @@ protected:
   virtual void touchKeyAtDepth(const octomap::OcTreeKey& key,
                                unsigned int depth=std::numeric_limits<unsigned int>::max());
 
-  /** @brief Update the cells in binary fashion from the given values and bounds. */
+  /** @brief Update the cells in binary fashion from the given values and bounds.
+   * Note: in this version, the value and bounds trees will have their depth
+   * changed to match the costmap */
+  virtual void updateCells(octomap::OcTree* value_map, octomap::OcTree* bounds_map,
+                           Cost occupied_threshold = LETHAL);
+
+  /** @brief Update the cells in binary fashion from the given values and bounds.
+   * Note: if the value_map or bounds_map have a different depth from the
+   * internal costmap_, the costmap_ will *not* be updated!
+   * To update from maps with different depths, use the updateCells version
+   * that takes non-const pointers to the maps, which will alter the depth of
+   * the input trees first to match. */
   virtual void updateCells(const octomap::OcTree& value_map, const octomap::OcTree& bounds_map,
                            Cost occupied_threshold = LETHAL);
 

--- a/costmap_3d/include/costmap_3d/layered_costmap_3d.h
+++ b/costmap_3d/include/costmap_3d/layered_costmap_3d.h
@@ -122,6 +122,9 @@ public:
 
   double getResolution() const;
 
+  /// Return true if the given pose is inside the map's coordinate system
+  bool isPoseInMap(geometry_msgs::Pose robot_pose);
+
   void getBounds(geometry_msgs::Point* min, geometry_msgs::Point* max);
 
   /**

--- a/costmap_3d/plugins/costmap_3d_to_2d_layer.cpp
+++ b/costmap_3d/plugins/costmap_3d_to_2d_layer.cpp
@@ -179,7 +179,12 @@ void Costmap3DTo2DLayer::updateBounds(double robot_x, double robot_y, double rob
         const int min_x_3d = (int)min_index_3d[0] - map_3d_ox;
         const int min_y_3d = (int)min_index_3d[1] - map_3d_oy;
         const octomap::key_type depth_diff_3d = master_3d->getTreeDepth() - it.getDepth();
-        const octomap::key_type size_3d = (((octomap::key_type)1u)<<depth_diff_3d) - 1u;
+        // avoid undefined behavior in the bit shift by special-case when
+        // depth diff is at or beyond the key's bit width
+        const octomap::key_type size_3d = (
+            depth_diff_3d >= octomap::KEY_BIT_WIDTH ?
+            std::numeric_limits<octomap::key_type>::max() :
+            (((octomap::key_type)1u)<<depth_diff_3d) - 1u);
         const int max_x_3d = min_x_3d + size_3d;
         const int max_y_3d = min_y_3d + size_3d;
         const unsigned char cost = toCostmap2D(it->getValue());

--- a/costmap_3d/plugins/octomap_server_layer_3d.cpp
+++ b/costmap_3d/plugins/octomap_server_layer_3d.cpp
@@ -425,7 +425,7 @@ void OctomapServerLayer3D::mapUpdateInternal(const octomap_msgs::Octomap* map_ms
       {
         ROS_DEBUG_STREAM("using bounds octomap with size " << bounds_map->size());
         // Use zero log odds as the threshold for any incoming binary map
-        updateCells(*map, *bounds_map, 0.0);
+        updateCells(map, bounds_map, 0.0);
         ROS_DEBUG_STREAM("after update cells, costmap_ has size " << costmap_->size());
         ROS_DEBUG_STREAM(" and changed_cells_ has size " << changed_cells_->size());
       }

--- a/costmap_3d/src/costmap_3d.cpp
+++ b/costmap_3d/src/costmap_3d.cpp
@@ -62,7 +62,7 @@ Costmap3D::Costmap3D(double resolution) : octomap::OcTree(resolution)
 
 octomap::point3d toOctomapPoint(const geometry_msgs::Point& point)
 {
-  return octomap::point3d((float)point.x, (float)point.y, (float)point.z);
+  return octomap::point3d(point.x, point.y, point.z);
 }
 
 geometry_msgs::Point fromOctomapPoint(const octomap::point3d& point)

--- a/costmap_3d/src/costmap_3d_ros.cpp
+++ b/costmap_3d/src/costmap_3d_ros.cpp
@@ -178,6 +178,27 @@ void Costmap3DROS::resetLayers()
   super::resetLayers();
 }
 
+bool Costmap3DROS::isCurrent()
+{
+  tf::Stamped<tf::Pose> pose;
+  if (getRobotPose(pose))
+  {
+    geometry_msgs::Pose pose_msg;
+    tf::poseTFToMsg(pose, pose_msg);
+    if (!layered_costmap_3d_.isPoseInMap(pose_msg))
+    {
+      ROS_ERROR_THROTTLE(5.0, "Robot is off the 3D costmap, marking costmap as non-current");
+      return false;
+    }
+  }
+  else
+  {
+    ROS_ERROR_THROTTLE(5.0, "Robot's position unknown, marking costmap as non-current");
+    return false;
+  }
+  return super::isCurrent() && layered_costmap_3d_.isCurrent();
+}
+
 std::shared_ptr<Costmap3DQuery> Costmap3DROS::getBufferedQuery(
         const std::string& footprint_mesh_resource,
         double padding)

--- a/costmap_3d/src/costmap_layer_3d.cpp
+++ b/costmap_3d/src/costmap_layer_3d.cpp
@@ -81,10 +81,10 @@ void CostmapLayer3D::updateCosts(const Costmap3D& bounds_map, Costmap3D* master_
     switch (combination_method_)
     {
       case GenericPlugin_Overwrite:
-        master_map->setTreeValues(costmap_.get(), &bounds_map, false, false);
+        master_map->setTreeValues(static_cast<const Costmap3D*>(costmap_.get()), &bounds_map, false, false);
         break;
       case GenericPlugin_Maximum:
-        master_map->setTreeValues(costmap_.get(), &bounds_map, true, false);
+        master_map->setTreeValues(static_cast<const Costmap3D*>(costmap_.get()), &bounds_map, true, false);
         break;
       default:
       case GenericPlugin_Nothing:

--- a/costmap_3d/src/costmap_layer_3d.cpp
+++ b/costmap_3d/src/costmap_layer_3d.cpp
@@ -201,6 +201,17 @@ void CostmapLayer3D::touchKeyAtDepth(const octomap::OcTreeKey& key, unsigned int
   }
 }
 
+void CostmapLayer3D::updateCells(octomap::OcTree* value_map, octomap::OcTree* bounds_map,
+                                 Cost occupied_threshold)
+{
+  if (costmap_ && value_map && bounds_map)
+  {
+    value_map->setTreeDepth(costmap_->getTreeDepth());
+    bounds_map->setTreeDepth(costmap_->getTreeDepth());
+    updateCells(*value_map, *bounds_map, occupied_threshold);
+  }
+}
+
 void CostmapLayer3D::updateCells(const octomap::OcTree& value_map, const octomap::OcTree& bounds_map,
                                  Cost occupied_threshold)
 {

--- a/costmap_3d/src/layered_costmap_3d.cpp
+++ b/costmap_3d/src/layered_costmap_3d.cpp
@@ -81,14 +81,14 @@ void LayeredCostmap3D::updateMap(geometry_msgs::Pose robot_pose)
   {
     // Adjust the x/y based on the x/y of the robot's pose, as a rolling map
     // stays centered on the robot base in x/y (but not z).
-    float robot_x = (float)robot_pose.position.x;
-    float robot_y = (float)robot_pose.position.y;
-    float aabb_width = aabb_max.x() - aabb_min.x();
-    float aabb_height = aabb_max.y() - aabb_min.y();
-    aabb_min.x() += robot_x - aabb_width/2.0f;
-    aabb_min.y() += robot_y - aabb_height/2.0f;
-    aabb_max.x() += robot_x - aabb_width/2.0f;
-    aabb_max.y() += robot_y - aabb_height/2.0f;
+    double robot_x = robot_pose.position.x;
+    double robot_y = robot_pose.position.y;
+    double aabb_width = aabb_max.x() - aabb_min.x();
+    double aabb_height = aabb_max.y() - aabb_min.y();
+    aabb_min.x() += robot_x - aabb_width/2.0;
+    aabb_min.y() += robot_y - aabb_height/2.0;
+    aabb_max.x() += robot_x - aabb_width/2.0;
+    aabb_max.y() += robot_y - aabb_height/2.0;
   }
   const geometry_msgs::Point min_msg(fromOctomapPoint(aabb_min));
   const geometry_msgs::Point max_msg(fromOctomapPoint(aabb_max));

--- a/costmap_3d/src/layered_costmap_3d.cpp
+++ b/costmap_3d/src/layered_costmap_3d.cpp
@@ -258,6 +258,17 @@ double LayeredCostmap3D::getResolution() const
   return resolution_;
 }
 
+bool LayeredCostmap3D::isPoseInMap(geometry_msgs::Pose robot_pose)
+{
+  double limit = costmap_->getNodeSize(1);
+  return (robot_pose.position.x < limit &&
+          robot_pose.position.x > -limit &&
+          robot_pose.position.y < limit &&
+          robot_pose.position.y > -limit &&
+          robot_pose.position.z < limit &&
+          robot_pose.position.z > -limit);
+}
+
 void LayeredCostmap3D::getBounds(geometry_msgs::Point* min, geometry_msgs::Point* max)
 {
   // keep the view of min/max consistent


### PR DESCRIPTION
costmap_3d: octomap coords are now doubles
costmap_3d: mark costmap stale if base off map
costmap_3d: ensure const setTreeValues
costmap_3d: add non-const version of updateCells
costmap_3d: fix potential undefined bit-shift

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/navigation/11)
<!-- Reviewable:end -->
