### PR TITLE
costmap_3d: clear exact cache on costmap update

### DIFF
--- a/costmap_3d/src/costmap_3d_query.cpp
+++ b/costmap_3d/src/costmap_3d_query.cpp
@@ -156,6 +156,7 @@ void Costmap3DQuery::checkCostmap(Costmap3DQuery::upgrade_lock& upgrade_lock)
     // which ones might still be valid.
     milli_distance_cache_.clear();
     micro_distance_cache_.clear();
+    exact_distance_cache_.clear();
     printStatistics();
     clearStatistics();
     last_layered_costmap_update_number_ = layered_costmap_3d_->getNumberOfUpdates();


### PR DESCRIPTION
Clear the exact cache on costmap update just like the other caches.
This was an oversight that leads to infinite memory growth over time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/navigation/14)
<!-- Reviewable:end -->
