### PR TITLE
costmap_3d: fix crash when querying non-lethal map

### DIFF
--- a/costmap_3d/src/costmap_3d_query.cpp
+++ b/costmap_3d/src/costmap_3d_query.cpp
@@ -615,7 +615,11 @@ double Costmap3DQuery::calculateDistance(geometry_msgs::Pose pose, bool signed_d
       new_entry,
       pose);
 
-  // Update distance caches
+  // Update distance caches.
+  // Note that it is possible for the result to be empty. The octomap might
+  // only contain non-lethal leaves and we may have missed every cache.
+  // If we get no result primitives, do not add null pointers to the cache!
+  if (new_entry.octomap_box && new_entry.mesh_triangle)
   {
     // Get write access
     unique_lock write_lock(upgrade_mutex_);


### PR DESCRIPTION
If the costmap contains only non-lethal leaves (such as free space or
"maybe" obstacles), and all caches are missed, the result from FCL
will be empty, as there is nothing to get a distance to. Check to be
sure the new cache entry is valid before updating the caches.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/navigation/15)
<!-- Reviewable:end -->
