### PR TITLE
costmap_3d: add ability to query left/right

### DIFF
--- a/costmap_3d/action/GetPlanCost3D.action
+++ b/costmap_3d/action/GetPlanCost3D.action
@@ -29,6 +29,16 @@ uint8 COST_QUERY_MODE_SIGNED_DISTANCE=3
 # The default is COST_QUERY_MODE_COST.
 uint8 cost_query_mode
 
+# Query entire map
+uint8 COST_QUERY_REGION_ALL=0
+# Query the map only to the left of each query pose.
+uint8 COST_QUERY_REGION_LEFT=1
+# Query the map only to the right of each query pose.
+uint8 COST_QUERY_REGION_RIGHT=2
+# Set to one of the above COST_QUERY_REGION_* to control query region per pose.
+# If the region is missing for a given pose, COST_QUERY_REGION_ALL is assumed.
+uint8[] cost_query_regions
+
 # An alternative footprint_mesh_resource to use (in base_footprint frame)
 # If empty, the default stored in the costmap will be used.
 string footprint_mesh_resource

--- a/costmap_3d/include/costmap_3d/costmap_3d_ros.h
+++ b/costmap_3d/include/costmap_3d/costmap_3d_ros.h
@@ -136,21 +136,24 @@ public:
    * @param pose                    pose to query
    * @param footprint_mesh_resource which footprint mesh to use, empty string means default
    * @param padding                 padding to add to the footprint. NAN means use default padding
+   * @param query_region            region of map to query at given pose
    *
    * @returns negative for lethal, otherwise the cost of the pose */
   virtual double footprintCost(geometry_msgs::Pose pose,
                                const std::string& footprint_mesh_resource = "",
-                               double padding = NAN);
+                               double padding = NAN,
+                               Costmap3DQuery::QueryRegion query_region = Costmap3DQuery::ALL);
 
   virtual double footprintCost(double x, double y, double theta,
                                const std::string& footprint_mesh_resource = "",
-                               double padding = NAN)
+                               double padding = NAN,
+                               Costmap3DQuery::QueryRegion query_region = Costmap3DQuery::ALL)
   {
     geometry_msgs::Pose pose;
     pose.position.x = x;
     pose.position.y = y;
     pose.orientation = tf::createQuaternionMsgFromYaw(theta);
-    return footprintCost(pose, footprint_mesh_resource, padding);
+    return footprintCost(pose, footprint_mesh_resource, padding, query_region);
   }
 
   /** @brief Return whether the given pose is in collision in the 3D costmap.
@@ -166,7 +169,8 @@ public:
    * @returns true if in collision, false otherwise */
   virtual bool footprintCollision(geometry_msgs::Pose pose,
                                   const std::string& footprint_mesh_resource = "",
-                                  double padding = NAN);
+                                  double padding = NAN,
+                                  Costmap3DQuery::QueryRegion query_region = Costmap3DQuery::ALL);
 
   /** @brief Return minimum distance to the nearest lethal 3D costmap object.
    * This returns the minimum unsigned distance or negative on a collision.
@@ -184,7 +188,8 @@ public:
    * @returns negative on collision, otherwise distance to nearest obstacle */
   virtual double footprintDistance(geometry_msgs::Pose pose,
                                    const std::string& footprint_mesh_resource = "",
-                                   double padding = NAN);
+                                   double padding = NAN,
+                                   Costmap3DQuery::QueryRegion query_region = Costmap3DQuery::ALL);
 
   /** @brief Return minimum signed distance to nearest 3D costmap object.
    * This returns the minimum signed distance. So, the deeper a pose goes into
@@ -200,7 +205,8 @@ public:
    * @returns exact signed distance to nearest obstacle */
   virtual double footprintSignedDistance(geometry_msgs::Pose pose,
                                          const std::string& footprint_mesh_resource = "",
-                                         double padding = NAN);
+                                         double padding = NAN,
+                                         Costmap3DQuery::QueryRegion query_region = Costmap3DQuery::ALL);
 
 protected:
   ros::NodeHandle private_nh_;

--- a/costmap_3d/scripts/get_current_pose_distance_3d.py
+++ b/costmap_3d/scripts/get_current_pose_distance_3d.py
@@ -32,7 +32,7 @@ if __name__ == "__main__":
                                       costmap_3d.srv.GetPlanCost3DService)
     req = costmap_3d.srv.GetPlanCost3DServiceRequest()
     req.lazy = False
-    req.buffered = True
+    req.buffered = False
     req.header.stamp = rospy.Time.now()
     req.cost_query_mode = costmap_3d.srv.GetPlanCost3DServiceRequest.COST_QUERY_MODE_DISTANCE
     # req.footprint_mesh_resource = "package://ant_description/meshes/robot-get-close-to-obstacle-backward.stl"
@@ -50,6 +50,11 @@ if __name__ == "__main__":
     pose.pose.orientation.z = 0.0
     pose.pose.orientation.w = 1.0
     req.poses.append(pose)
+    req.poses.append(pose)
+    req.poses.append(pose)
+    req.cost_query_regions = [costmap_3d.srv.GetPlanCost3DServiceRequest.COST_QUERY_REGION_ALL,
+                              costmap_3d.srv.GetPlanCost3DServiceRequest.COST_QUERY_REGION_LEFT,
+                              costmap_3d.srv.GetPlanCost3DServiceRequest.COST_QUERY_REGION_RIGHT]
     rospy.loginfo("Request: " + str(req))
     res = get_cost_srv(req)
     rospy.loginfo("Result: " + str(res))

--- a/costmap_3d/src/costmap_3d_query.cpp
+++ b/costmap_3d/src/costmap_3d_query.cpp
@@ -404,14 +404,10 @@ double Costmap3DQuery::handleDistanceInteriorCollisions(
     if (signed_distance)
     {
       // Modify the signed distance.
-      // If not already in collision, negate the distance (so we have the
-      // negative of nearest octomap cell in interior of the volume)
-      if (distance > 0.0)
-      {
-        distance = -distance;
-      }
-      // Instead of attempting to exactly calculate the deepest point on the
-      // colliding octomap box, approximate the penetration depth by
+      // First negate the distance (so we have the negative of nearest octomap
+      // cell in interior of the volume, or the positive amount of overlap)
+      // Then, Instead of attempting to exactly calculate the deepest point on
+      // the colliding octomap box, approximate the penetration depth by
       // subtracting the bounding diameter of the box.
       // This results in exaggerated penetration distances in some cases (such
       // as on or near the boundary), and obviously also results in not enough
@@ -419,7 +415,7 @@ double Costmap3DQuery::handleDistanceInteriorCollisions(
       // distance only gives us the nearest octomap box to the mesh)
       // If exact signed distance were required, FCL would need to be modified
       // to work with general polyhedra volumes.
-      distance -= cache_entry.octomap_box->side.norm();
+      distance = -distance - cache_entry.octomap_box->side.norm();
     }
     else
     {

--- a/costmap_3d/src/costmap_3d_ros.cpp
+++ b/costmap_3d/src/costmap_3d_ros.cpp
@@ -363,30 +363,34 @@ std::shared_ptr<Costmap3DQuery> Costmap3DROS::getQuery(const std::string& footpr
 
 double Costmap3DROS::footprintCost(geometry_msgs::Pose pose,
                                    const std::string& footprint_mesh_resource,
-                                   double padding)
+                                   double padding,
+                                   Costmap3DQuery::QueryRegion query_region)
 {
-  return getQuery(footprint_mesh_resource, padding)->footprintCost(pose);
+  return getQuery(footprint_mesh_resource, padding)->footprintCost(pose, query_region);
 }
 
 bool Costmap3DROS::footprintCollision(geometry_msgs::Pose pose,
                                       const std::string& footprint_mesh_resource,
-                                      double padding)
+                                      double padding,
+                                      Costmap3DQuery::QueryRegion query_region)
 {
-  return getQuery(footprint_mesh_resource, padding)->footprintCollision(pose);
+  return getQuery(footprint_mesh_resource, padding)->footprintCollision(pose, query_region);
 }
 
 double Costmap3DROS::footprintDistance(geometry_msgs::Pose pose,
                                        const std::string& footprint_mesh_resource,
-                                       double padding)
+                                       double padding,
+                                       Costmap3DQuery::QueryRegion query_region)
 {
-  return getQuery(footprint_mesh_resource, padding)->footprintDistance(pose);
+  return getQuery(footprint_mesh_resource, padding)->footprintDistance(pose, query_region);
 }
 
 double Costmap3DROS::footprintSignedDistance(geometry_msgs::Pose pose,
                                              const std::string& footprint_mesh_resource,
-                                             double padding)
+                                             double padding,
+                                             Costmap3DQuery::QueryRegion query_region)
 {
-  return getQuery(footprint_mesh_resource, padding)->footprintSignedDistance(pose);
+  return getQuery(footprint_mesh_resource, padding)->footprintSignedDistance(pose, query_region);
 }
 
 void Costmap3DROS::getPlanCost3DActionCallback(
@@ -446,6 +450,12 @@ void Costmap3DROS::processPlanCost3D(RequestType& request, ResponseType& respons
   {
     bool collision = false;
 
+    Costmap3DQuery::QueryRegion query_region = Costmap3DQuery::ALL;
+    if (i < request.cost_query_regions.size())
+    {
+      query_region = request.cost_query_regions[i];
+    }
+
     geometry_msgs::PoseStamped pose;
     float timeout_seconds = (request.transform_wait_time_limit > 0) ?
       request.transform_wait_time_limit : 0.1;
@@ -459,19 +469,19 @@ void Costmap3DROS::processPlanCost3D(RequestType& request, ResponseType& respons
 
       if (request.cost_query_mode == GetPlanCost3DService::Request::COST_QUERY_MODE_COLLISION_ONLY)
       {
-        pose_cost = query->footprintCollision(pose.pose) ? -1.0 : 0.0;
+        pose_cost = query->footprintCollision(pose.pose, query_region) ? -1.0 : 0.0;
       }
       else if (request.cost_query_mode == GetPlanCost3DService::Request::COST_QUERY_MODE_DISTANCE)
       {
-        pose_cost = query->footprintDistance(pose.pose);
+        pose_cost = query->footprintDistance(pose.pose, query_region);
       }
       else if (request.cost_query_mode == GetPlanCost3DService::Request::COST_QUERY_MODE_SIGNED_DISTANCE)
       {
-        pose_cost = query->footprintSignedDistance(pose.pose);
+        pose_cost = query->footprintSignedDistance(pose.pose, query_region);
       }
       else
       {
-        pose_cost = query->footprintCost(pose.pose);
+        pose_cost = query->footprintCost(pose.pose, query_region);
       }
     }
     else

--- a/costmap_3d/srv/GetPlanCost3DService.srv
+++ b/costmap_3d/srv/GetPlanCost3DService.srv
@@ -29,6 +29,16 @@ uint8 COST_QUERY_MODE_SIGNED_DISTANCE=3
 # The default is COST_QUERY_MODE_COST.
 uint8 cost_query_mode
 
+# Query entire map
+uint8 COST_QUERY_REGION_ALL=0
+# Query the map only to the left of each query pose.
+uint8 COST_QUERY_REGION_LEFT=1
+# Query the map only to the right of each query pose.
+uint8 COST_QUERY_REGION_RIGHT=2
+# Set to one of the above COST_QUERY_REGION_* to control query region per pose.
+# If the region is missing for a given pose, COST_QUERY_REGION_ALL is assumed.
+uint8[] cost_query_regions
+
 # An alternative footprint_mesh_resource to use (in base_footprint frame)
 # If empty, the default stored in the costmap will be used.
 string footprint_mesh_resource


### PR DESCRIPTION
Add the option to query only left or right of the given pose.
This option ignores the region of the map on the other side for the
queries.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/navigation/16)
<!-- Reviewable:end -->
