### PR TITLE
Fix signed distance: phase 1

### DIFF
--- a/costmap_3d/include/costmap_3d/costmap_3d_query.h
+++ b/costmap_3d/include/costmap_3d/costmap_3d_query.h
@@ -198,6 +198,8 @@ protected:
                                    QueryRegion query_region = ALL);
 
 private:
+  // Common initialization between all constrcutors
+  void init();
   // synchronize this object for parallel queries
   upgrade_mutex upgrade_mutex_;
   // returns path to package file, or empty on error
@@ -471,21 +473,15 @@ private:
    * massive speed up for cases where the nearest obstacle is futher than the
    * milli_cache_threshold_
    */
-  double milli_cache_threshold_ = .125;
+  double milli_cache_threshold_;
   DistanceCache milli_distance_cache_;
   /**
-   * The micro-distance cache allows us to return a guess as to the distance
-   * based on hitting the micro-cache. The number of bins in the micro-cache
-   * must be large to prevent gross error. If the micro-cache is hit on a
-   * distance query, instead of making a query, the cached triangle is
-   * transformed to the new pose, and the distance between that triangle and
-   * the previous octomap box is returned immediately. This results in a
-   * massive speed-up when querying very small changes in pose (which may
-   * be done to calculate derivatives, for instance). Do note that this
-   * cache is a potential source of minor error, so in cases where that is
-   * important use a very high number of bins (which will reduce its
-   * efficiency for the sake of accuracy).
+   * The micro-distance cache allows a very fast path when the nearest
+   * obstacle is more than a threshold of distance away. This results in a
+   * massive speed up for cases where the nearest obstacle is futher than the
+   * micro_cache_threshold_
    */
+  double micro_cache_threshold_;
   DistanceCache micro_distance_cache_;
   // Immediately return the distance for an exact duplicate query
   // This avoid any calculation in the case that the calculation has been done
@@ -514,13 +510,15 @@ private:
   std::atomic<unsigned int> hits_since_clear_;
   std::atomic<unsigned int> fast_milli_hits_since_clear_;
   std::atomic<unsigned int> slow_milli_hits_since_clear_;
-  std::atomic<unsigned int> micro_hits_since_clear_;
+  std::atomic<unsigned int> fast_micro_hits_since_clear_;
+  std::atomic<unsigned int> slow_micro_hits_since_clear_;
   std::atomic<unsigned int> exact_hits_since_clear_;
   std::atomic<uint64_t> misses_since_clear_us_;
   std::atomic<uint64_t> hits_since_clear_us_;
   std::atomic<uint64_t> fast_milli_hits_since_clear_us_;
   std::atomic<uint64_t> slow_milli_hits_since_clear_us_;
-  std::atomic<uint64_t> micro_hits_since_clear_us_;
+  std::atomic<uint64_t> fast_micro_hits_since_clear_us_;
+  std::atomic<uint64_t> slow_micro_hits_since_clear_us_;
   std::atomic<uint64_t> exact_hits_since_clear_us_;
   std::atomic<size_t> hit_fcl_bv_distance_calculations_;
   std::atomic<size_t> hit_fcl_primative_distance_calculations_;

--- a/costmap_3d/include/costmap_3d/costmap_3d_query.h
+++ b/costmap_3d/include/costmap_3d/costmap_3d_query.h
@@ -371,13 +371,15 @@ private:
   public:
     DistanceCacheEntry() {}
     DistanceCacheEntry(const DistanceCacheEntry& rhs)
-        : octomap_box(rhs.octomap_box),
+        : distance(rhs.distance),
+          octomap_box(rhs.octomap_box),
           octomap_box_tf(rhs.octomap_box_tf),
           mesh_triangle(rhs.mesh_triangle)
     {
     }
     const DistanceCacheEntry& operator=(const DistanceCacheEntry& rhs)
     {
+      distance = rhs.distance;
       octomap_box = rhs.octomap_box;
       octomap_box_tf = rhs.octomap_box_tf;
       mesh_triangle = rhs.mesh_triangle;
@@ -387,6 +389,7 @@ private:
     {
       assert(result.primitive1);
       assert(result.primitive2);
+      distance = result.min_distance;
       octomap_box = std::dynamic_pointer_cast<fcl::Box<FCLFloat>>(result.primitive1);
       octomap_box_tf = result.tf1;
       mesh_triangle = std::dynamic_pointer_cast<fcl::TriangleP<FCLFloat>>(result.primitive2);
@@ -437,6 +440,7 @@ private:
       }
       return dist;
     }
+    FCLFloat distance;
     std::shared_ptr<fcl::Box<FCLFloat>> octomap_box;
     fcl::Transform3<FCLFloat> octomap_box_tf;
     std::shared_ptr<fcl::TriangleP<FCLFloat>> mesh_triangle;

--- a/costmap_3d/scripts/get_current_pose_distance_3d.py
+++ b/costmap_3d/scripts/get_current_pose_distance_3d.py
@@ -12,7 +12,7 @@ import rospy
 #import tf.transformations
 import costmap_3d.srv
 import geometry_msgs.msg
-#import copy
+import copy
 
 
 if __name__ == "__main__":
@@ -34,7 +34,7 @@ if __name__ == "__main__":
     req.lazy = False
     req.buffered = False
     req.header.stamp = rospy.Time.now()
-    req.cost_query_mode = costmap_3d.srv.GetPlanCost3DServiceRequest.COST_QUERY_MODE_DISTANCE
+    req.cost_query_mode = costmap_3d.srv.GetPlanCost3DServiceRequest.COST_QUERY_MODE_SIGNED_DISTANCE
     # req.footprint_mesh_resource = "package://ant_description/meshes/robot-get-close-to-obstacle-backward.stl"
     # req.padding = float('NaN')
     # req.footprint_mesh_resource = ""
@@ -49,13 +49,23 @@ if __name__ == "__main__":
     pose.pose.orientation.y = 0.0
     pose.pose.orientation.z = 0.0
     pose.pose.orientation.w = 1.0
-    req.poses.append(pose)
-    req.poses.append(pose)
-    req.poses.append(pose)
-    req.cost_query_regions = [costmap_3d.srv.GetPlanCost3DServiceRequest.COST_QUERY_REGION_ALL,
-                              costmap_3d.srv.GetPlanCost3DServiceRequest.COST_QUERY_REGION_LEFT,
-                              costmap_3d.srv.GetPlanCost3DServiceRequest.COST_QUERY_REGION_RIGHT]
+    req.poses.append(copy.deepcopy(pose))
+    pose.pose.position.x = x + 1e-5
+    req.poses.append(copy.deepcopy(pose))
+    pose.pose.position.x = x
+    pose.pose.position.y = y + 1e-5
+    req.poses.append(copy.deepcopy(pose))
+    pose.pose.position.y = y
+    pose.pose.orientation.z += 1e-5
+    pose.pose.orientation.w -= 1e-5
+    req.poses.append(copy.deepcopy(pose))
+#    req.cost_query_regions = [costmap_3d.srv.GetPlanCost3DServiceRequest.COST_QUERY_REGION_ALL,
+#                              costmap_3d.srv.GetPlanCost3DServiceRequest.COST_QUERY_REGION_LEFT,
+#                              costmap_3d.srv.GetPlanCost3DServiceRequest.COST_QUERY_REGION_RIGHT]
     rospy.loginfo("Request: " + str(req))
     res = get_cost_srv(req)
     rospy.loginfo("Result: " + str(res))
     rospy.loginfo("Number of lethals: " + str(len(res.lethal_indices)))
+    rospy.loginfo(" dx: " + str(1e5 * (res.pose_costs[1]-res.pose_costs[0])))
+    rospy.loginfo(" dy: " + str(1e5 * (res.pose_costs[2]-res.pose_costs[0])))
+    rospy.loginfo(" dt: " + str(1e5 * (res.pose_costs[3]-res.pose_costs[0])))

--- a/costmap_3d/scripts/test_get_pose_collision_3d_in_grid.py
+++ b/costmap_3d/scripts/test_get_pose_collision_3d_in_grid.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+"""
+Test the performance of 3D costmap by sending a veyr large get plan cost service requests.
+"""
+
+import sys
+import math
+import random
+import rospy
+import tf2_ros
+import tf2_geometry_msgs
+import tf.transformations
+import costmap_3d.srv
+import geometry_msgs.msg
+import sensor_msgs.msg
+import copy
+
+
+if __name__ == "__main__":
+
+    rospy.init_node("test_costmap3d_get_plan_cost_performance", anonymous=True)
+
+    tfBuffer = tf2_ros.Buffer()
+    tfListener = tf2_ros.TransformListener(tfBuffer)
+
+    try:
+        xform = tfBuffer.lookup_transform('odom', 'base_footprint',
+                rospy.Time(0.0), rospy.Duration(10.0))
+
+    except tf2_ros.TransformException as e:
+        rospy.logerr("Cannot determine base footprint transform")
+        sys.exit(1)
+
+    pose_array_pub = rospy.Publisher("/test_costmap_3d/pose_array",
+            geometry_msgs.msg.PoseArray, queue_size=1, latch=True)
+    point_cloud_pub = rospy.Publisher("/test_costmap_3d/distance_cloud",
+            sensor_msgs.msg.PointCloud, queue_size=1, latch=True)
+    test_ns = "/move_base/local_costmap/"
+    get_cost_srv = rospy.ServiceProxy(test_ns + "get_plan_cost_3d",
+            costmap_3d.srv.GetPlanCost3DService)
+    frame = "odom"
+    pose_array = geometry_msgs.msg.PoseArray()
+    pose_array.header.frame_id = frame
+    pose_array.header.stamp = rospy.Time.now()
+    req = costmap_3d.srv.GetPlanCost3DServiceRequest()
+    req.lazy = False
+    req.buffered = False
+    req.header.frame_id = frame
+    req.header.stamp = pose_array.header.stamp
+    req.cost_query_mode = costmap_3d.srv.GetPlanCost3DServiceRequest.COST_QUERY_MODE_SIGNED_DISTANCE
+#    req.cost_query_mode = costmap_3d.srv.GetPlanCost3DServiceRequest.COST_QUERY_MODE_DISTANCE
+#    req.cost_query_mode = costmap_3d.srv.GetPlanCost3DServiceRequest.COST_QUERY_MODE_COLLISION_ONLY
+    req.footprint_mesh_resource = ""
+#    req.footprint_mesh_resource = "package://ant_description/meshes/robot-get-close-to-obstacle-backward.stl"
+    req.padding = 0.0
+#    req.padding = 0.25
+    x_start = 0.0
+    y_start = 0.0
+    x_res = 0.01
+    y_res = 0.01
+    x_0 = -200
+    y_0 = -200
+    x_n = 200
+    y_n = 200
+    regions = []
+    for i in range(x_0, x_n):
+        for j in range(y_0, y_n):
+            pose = geometry_msgs.msg.PoseStamped()
+            pose.header.frame_id = frame
+            pose.pose.position.x = x_start + i * x_res
+            pose.pose.position.y = y_start + j * y_res
+            pose.pose.position.z = 0.0
+            theta = 0.5
+            q = tf.transformations.quaternion_from_euler(0.0, 0.0, theta)
+            pose.pose.orientation.x = q[0]
+            pose.pose.orientation.y = q[1]
+            pose.pose.orientation.z = q[2]
+            pose.pose.orientation.w = q[3]
+            req.poses.append(tf2_geometry_msgs.do_transform_pose(pose, xform))
+            regions.append(costmap_3d.srv.GetPlanCost3DServiceRequest.COST_QUERY_REGION_ALL)
+            pose_array.poses.append(tf2_geometry_msgs.do_transform_pose(pose, xform).pose)
+    req.cost_query_regions = regions
+
+    pose_array_pub.publish(pose_array)
+
+#    rospy.loginfo("Request: " + str(req))
+    res = get_cost_srv(req)
+
+    point_cloud = sensor_msgs.msg.PointCloud()
+    point_cloud.header = pose_array.header
+    for p, cost in zip(pose_array.poses, res.pose_costs):
+        z = -cost
+        if (z > 0):
+            z += 0.5;
+        if (z > 5.0):
+            z = 5.0;
+        if (z < -5.0):
+            z = -5.0;
+        point_cloud.points.append(geometry_msgs.msg.Point32(p.position.x, p.position.y, z))
+    point_cloud_pub.publish(point_cloud)
+
+#    rospy.loginfo("Result: " + str(res))
+#    rospy.loginfo("Number of lethals: " + str(len(res.lethal_indices)))
+    rospy.spin()

--- a/costmap_3d/src/costmap_3d_query.cpp
+++ b/costmap_3d/src/costmap_3d_query.cpp
@@ -738,7 +738,7 @@ double Costmap3DQuery::calculateDistance(geometry_msgs::Pose pose,
   // If we get no result primitives, do not add null pointers to the cache!
   if (result.primitive1 && result.primitive2)
   {
-    const DistanceCacheEntry& new_entry = DistanceCacheEntry(result);
+    DistanceCacheEntry new_entry(result);
 
     // Emulate signed distance in a similar way as FCL. FCL re-does the whole
     // tree/BVH collision, but we already know the colliding primitives, so save
@@ -753,6 +753,8 @@ double Costmap3DQuery::calculateDistance(geometry_msgs::Pose pose,
         signed_distance,
         new_entry,
         pose);
+
+    new_entry.distance = distance;
 
     // Update distance caches.
     {

--- a/costmap_3d/src/costmap_3d_query.cpp
+++ b/costmap_3d/src/costmap_3d_query.cpp
@@ -604,7 +604,7 @@ double Costmap3DQuery::calculateDistance(geometry_msgs::Pose pose,
       // The upper-bound distance must not go through
       // handleDistanceInteriorCollisions, because that could artificially
       // prevent fcl::distance from getting the box nearest the mesh.
-      double distance = milli_cache_entry->second.distanceToNewPose(pose, false);
+      double distance = milli_cache_entry->second.distanceToNewPose(pose, signed_distance);
       if (distance < pose_distance)
       {
         milli_hit = true;
@@ -642,7 +642,7 @@ double Costmap3DQuery::calculateDistance(geometry_msgs::Pose pose,
       // The upper-bound distance must not go through
       // handleDistanceInteriorCollisions, because that could artificially
       // prevent fcl::distance from getting the box nearest the mesh.
-      double distance = micro_cache_entry->second.distanceToNewPose(pose, false);
+      double distance = micro_cache_entry->second.distanceToNewPose(pose, signed_distance);
       if (distance < pose_distance)
       {
         micro_hit = true;
@@ -670,7 +670,7 @@ double Costmap3DQuery::calculateDistance(geometry_msgs::Pose pose,
       // This upper-bound distance must not go through
       // handleDistanceInteriorCollisions, because that could artificially
       // prevent fcl::distance from getting the box nearest the mesh.
-      pose_distance = cache_entry->second.distanceToNewPose(pose, false);
+      pose_distance = cache_entry->second.distanceToNewPose(pose, signed_distance);
       cache_entry->second.setupResult(&result);
     }
   }
@@ -680,7 +680,7 @@ double Costmap3DQuery::calculateDistance(geometry_msgs::Pose pose,
   // last entry, and the queries are being done on a path.
   if (tls_last_cache_entries_[query_region])
   {
-    double last_entry_distance = tls_last_cache_entries_[query_region]->distanceToNewPose(pose, false);
+    double last_entry_distance = tls_last_cache_entries_[query_region]->distanceToNewPose(pose, signed_distance);
     if (last_entry_distance < pose_distance)
     {
       pose_distance = last_entry_distance;
@@ -745,7 +745,7 @@ double Costmap3DQuery::calculateDistance(geometry_msgs::Pose pose,
     // time by calculating their penetration depth directly.
     if (signed_distance && distance < 0.0)
     {
-      distance = new_entry.distanceToNewPose(pose, true);
+      distance = new_entry.distanceToNewPose(pose, signed_distance);
     }
 
     distance = handleDistanceInteriorCollisions(


### PR DESCRIPTION
Phase 1 of fixing the signed distance queries. This fix cleans up several outstanding issues, including incorrect derivatives when querying intersecting cases between the mesh and map by modeling the triangle face being penetrated as a half-space and finding the accurate penetration depth of the octomap box into that halfspace.

This fix also includes some bug-fixes around collision cases w/ the various caches.

Also included is the ability to reuse results to make creating the derivative more efficient by avoiding the cache lookup (avoiding recalculating the hash and finding the correct entry in the hash tables for the caches).

Still to be done in Phase 2:

* Fix the interior collision being missed when another octomap cell is nearer the mesh.
* More accurately model penetration depth to remove most of the stair-stepping effect inside obstacles

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/navigation/18)
<!-- Reviewable:end -->
