### PR TITLE
Fix interior collisions, buffered query improvements

### DIFF
--- a/base_local_planner/include/base_local_planner/costmap_3d_model.h
+++ b/base_local_planner/include/base_local_planner/costmap_3d_model.h
@@ -64,6 +64,12 @@ class Costmap3DModel : public CostmapModel
   virtual ~Costmap3DModel() {}
 
   /**
+   * @brief Set the query object to use
+   * @param costmap_3d_query The Costmap3DQuery to use
+   */
+  void setQuery(costmap_3d::Costmap3DQueryPtr costmap_3d_query) { costmap_3d_query_ = costmap_3d_query; }
+
+  /**
    * @brief Checks if any obstacles in the 3D costmap lie inside the default 3D footprint
    *
    * The caller must have the costmap 3D associated with this object locked
@@ -114,6 +120,7 @@ class Costmap3DModel : public CostmapModel
 
  protected:
   costmap_3d::Costmap3DROS& costmap_3d_; ///< @brief To query 3D costmap
+  costmap_3d::Costmap3DQueryPtr costmap_3d_query_; ///< @brief Alternate interface, query direct
 };
 
 }  // namespace base_local_planner

--- a/base_local_planner/src/costmap_3d_model.cpp
+++ b/base_local_planner/src/costmap_3d_model.cpp
@@ -66,7 +66,16 @@ double Costmap3DModel::footprintCost(
     double inscribed_radius,
     double circumscribed_radius)
 {
-  return costmap_3d_.footprintCost(x, y, theta);
+  geometry_msgs::Pose pose;
+  pose.position.x = x;
+  pose.position.y = y;
+  pose.orientation = tf::createQuaternionMsgFromYaw(theta);
+  if ( costmap_3d_query_ )
+  {
+    // Use any direct query, if available
+    return costmap_3d_query_->footprintCost(pose);
+  }
+  return costmap_3d_.footprintCost(pose);
 }
 
 }  // end namespace base_local_planner

--- a/costmap_3d/include/costmap_3d/costmap_3d.h
+++ b/costmap_3d/include/costmap_3d/costmap_3d.h
@@ -67,6 +67,9 @@ class Costmap3D : public octomap::OcTree
 {
 public:
   Costmap3D(double resolution);
+  Costmap3D(const Costmap3D& rhs);
+protected:
+  virtual void init();
 };
 
 typedef std::shared_ptr<Costmap3D> Costmap3DPtr;

--- a/costmap_3d/include/costmap_3d/costmap_3d_query.h
+++ b/costmap_3d/include/costmap_3d/costmap_3d_query.h
@@ -55,20 +55,11 @@
 #include <costmap_3d/layered_costmap_3d.h>
 #include <costmap_3d/crop_hull.h>
 #include <costmap_3d/GetPlanCost3DService.h>
+#include <costmap_3d/fcl_helper.h>
+#include <costmap_3d/interior_collision_lut.h>
 
 namespace costmap_3d
 {
-
-template <typename S>
-inline fcl::Transform3<S> poseToFCLTransform(const geometry_msgs::Pose& pose)
-{
-  return fcl::Transform3<S>(
-      fcl::Translation3<S>(pose.position.x, pose.position.y, pose.position.z) *
-      fcl::Quaternion<S>(pose.orientation.w,
-                         pose.orientation.x,
-                         pose.orientation.y,
-                         pose.orientation.z));
-}
 
 /** @brief Query a 3D Costmap. */
 class Costmap3DQuery
@@ -239,10 +230,14 @@ private:
   CropHull<pcl::PointXYZ> crop_hull_;
 
   using FCLFloat = double;
+  using FCLSolver = fcl::detail::GJKSolver_libccd<FCLFloat>;
   using FCLRobotModel = fcl::BVHModel<fcl::OBBRSS<FCLFloat>>;
   using FCLRobotModelPtr = std::shared_ptr<FCLRobotModel>;
 
   FCLRobotModelPtr robot_model_;
+  // The halfspaces are indexed the same as the robot model, and shared with
+  // the interior collision LUT, so make them a shared pointer
+  std::shared_ptr<std::vector<fcl::Halfspace<FCLFloat>>> robot_model_halfspaces_;
 
   using FCLCollisionObject = fcl::CollisionObject<FCLFloat>;
   using FCLCollisionObjectPtr = std::shared_ptr<FCLCollisionObject>;
@@ -272,16 +267,6 @@ private:
     }  // for point
   }
 
-  inline fcl::Vector3<FCLFloat> convertPCLPointToFCL(const pcl::PointXYZ& p)
-  {
-    return fcl::Vector3<FCLFloat>(p.x, p.y, p.z);
-  }
-
-  inline pcl::PointXYZ convertFCLPointToPCL(const fcl::Vector3<FCLFloat>& p)
-  {
-    return pcl::PointXYZ(p.x(), p.y(), p.z());
-  }
-
   // Add fcl triangles to the mesh vector for all triangles in a PCL polygon
   void addPCLPolygonToFCLTriangles(
       const pcl::Vertices& polygon,
@@ -292,6 +277,15 @@ private:
       const pcl::PolygonMesh& pcl_mesh,
       double padding,
       FCLRobotModel* robot_model);
+
+  InteriorCollisionLUT<FCLFloat> interior_collision_lut_;
+  double last_octomap_resolution_;
+  void checkInteriorCollisionLUT();
+  FCLFloat boxHalfspaceSignedDistance(
+      const fcl::Box<FCLFloat>& box,
+      const fcl::Transform3<FCLFloat>& box_tf,
+      int mesh_triangle_id,
+      const fcl::Transform3<FCLFloat>& mesh_tf) const;
 
   class DistanceCacheKey
   {
@@ -393,7 +387,8 @@ private:
         : distance(rhs.distance),
           octomap_box(rhs.octomap_box),
           octomap_box_tf(rhs.octomap_box_tf),
-          mesh_triangle(rhs.mesh_triangle)
+          mesh_triangle(rhs.mesh_triangle),
+          mesh_triangle_id(rhs.mesh_triangle_id)
     {
     }
     const DistanceCacheEntry& operator=(const DistanceCacheEntry& rhs)
@@ -402,6 +397,7 @@ private:
       octomap_box = rhs.octomap_box;
       octomap_box_tf = rhs.octomap_box_tf;
       mesh_triangle = rhs.mesh_triangle;
+      mesh_triangle_id = rhs.mesh_triangle_id;
       return *this;
     }
     DistanceCacheEntry(const fcl::DistanceResult<FCLFloat>& result)
@@ -412,6 +408,7 @@ private:
       octomap_box = std::dynamic_pointer_cast<fcl::Box<FCLFloat>>(result.primitive1);
       octomap_box_tf = result.tf1;
       mesh_triangle = std::dynamic_pointer_cast<fcl::TriangleP<FCLFloat>>(result.primitive2);
+      mesh_triangle_id = result.b2;
       assert(octomap_box);
       assert(mesh_triangle);
     }
@@ -420,68 +417,16 @@ private:
       result->primitive1 = octomap_box;
       result->primitive2 = mesh_triangle;
       result->tf1 = octomap_box_tf;
-    }
-    // Note: this code assumes the box is only translated in the fixed frame,
-    // not rotated, which is true of octomap boxes
-    static inline FCLFloat boxHalfspaceSignedDistance(const fcl::Box<FCLFloat>& box, const fcl::Transform3<FCLFloat>& box_tf, const fcl::Halfspace<FCLFloat>& halfspace)
-    {
-      const fcl::Vector3<FCLFloat>& normal = halfspace.n;
-      fcl::Vector3<FCLFloat> n_dot_d_components(normal[0] * box.side[0], normal[1] * box.side[1], normal[2] * box.side[2]);
-      fcl::Vector3<FCLFloat> n_dot_d_abs = n_dot_d_components.cwiseAbs();
-      FCLFloat box_extent = 0.5 * (n_dot_d_abs[0] + n_dot_d_abs[1] + n_dot_d_abs[2]);
-      FCLFloat depth = box_extent - halfspace.signedDistance(box_tf.translation());
-      return -depth;
-    }
-    // Find the signed distance between the octomap box and a halfspace
-    // defined by the mesh triangle. This may not be a good estimate of the
-    // distance between the costmap and the mesh when not in collision, but a
-    // very good estimate when in collision, so this function is used to
-    // refine signed distance queries.
-    inline FCLFloat boxHalfspaceSignedDistance(const fcl::Transform3<FCLFloat>& mesh_tf) const
-    {
-      // Find the normal for this triangle in the mesh.
-      // Note: we could pre-calculate all the normals and half-spaces for the mesh.
-      fcl::Vector3<FCLFloat> vec_a_b = mesh_triangle->a - mesh_triangle->b;
-      fcl::Vector3<FCLFloat> vec_a_c = mesh_triangle->a - mesh_triangle->c;
-      fcl::Vector3<FCLFloat> normal = vec_a_b.cross(vec_a_c).normalized();
-      FCLFloat plane_distance = mesh_triangle->a.dot(normal);
-      // Transform the halfspace into the fixed frame at the new pose
-      fcl::Halfspace<FCLFloat> halfspace(fcl::transform(
-          fcl::Halfspace<FCLFloat>(normal, plane_distance), mesh_tf));
-      // Find the penetration depth of the box into the halfspace.
-      // FCL doesn't have a function to do this directly, unfortunately.
-      return boxHalfspaceSignedDistance(*octomap_box, octomap_box_tf, halfspace);
-    }
-    FCLFloat distanceToNewPose(geometry_msgs::Pose pose, bool signed_distance=false) const
-    {
-      // Turn pose into tf
-      fcl::Transform3<FCLFloat> new_tf(costmap_3d::poseToFCLTransform<FCLFloat>(pose));
-
-      FCLFloat dist;
-      // As of the time this code was written, the normal FCL API does not
-      // allow box/triangle distance or signed distance queries.
-      // Yet FCL internally does such checks all the time, so use the
-      // internal mechanism for now.
-      fcl::detail::GJKSolver_libccd<FCLFloat> solver;
-      solver.shapeTriangleDistance(*octomap_box, octomap_box_tf,
-                                   mesh_triangle->a, mesh_triangle->b, mesh_triangle->c, new_tf,
-                                   &dist);
-      if (signed_distance && dist < 0.0)
-      {
-        dist = boxHalfspaceSignedDistance(new_tf);
-        assert(dist <= 0.0);
-      }
-      return dist;
+      result->b2 = mesh_triangle_id;
     }
     FCLFloat distance;
     std::shared_ptr<fcl::Box<FCLFloat>> octomap_box;
     fcl::Transform3<FCLFloat> octomap_box_tf;
     std::shared_ptr<fcl::TriangleP<FCLFloat>> mesh_triangle;
+    int mesh_triangle_id;
   };
   // used by distance calculation to find interior collisions
   double handleDistanceInteriorCollisions(
-      double distance,
-      bool signed_distance,
       const DistanceCacheEntry& cache_entry,
       const geometry_msgs::Pose& pose);
   using DistanceCache = std::unordered_map<DistanceCacheKey, DistanceCacheEntry, DistanceCacheKeyHash, DistanceCacheKeyEqual>;

--- a/costmap_3d/include/costmap_3d/costmap_3d_query.h
+++ b/costmap_3d/include/costmap_3d/costmap_3d_query.h
@@ -189,6 +189,25 @@ public:
   /** @brief get a const reference to the mesh polygons being used */
   const std::vector<pcl::Vertices>& getRobotMeshPolygons() const {return robot_mesh_.polygons;}
 
+  /** @brief set the layered costmap update number.
+   *
+   * This is useful for buffered queries to store which costmap update they represent.
+   */
+  void setLayeredCostmapUpdateNumber(unsigned int n) { last_layered_costmap_update_number_ = n; }
+
+  /** @brief get the layered costmap update number.
+   *
+   * This is useful for buffered queries to store which costmap update they represent.
+   */
+  unsigned int getLayeredCostmapUpdateNumber() const { return last_layered_costmap_update_number_; }
+
+  /** @brief change the costmap associated with this query.
+   *
+   * This is useful for a buffered query to save the robot mesh LUT, which would be
+   * re-created if a new query is allocated.
+   */
+  void updateCostmap(const Costmap3DConstPtr& costmap_3d);
+
 protected:
   const LayeredCostmap3D* layered_costmap_3d_;
 
@@ -203,8 +222,10 @@ protected:
    * the resolution changes.
    * Note: assumes the costmap is locked. The costmap should always be locked
    * during query calls when this is called.
+   * If the associated layered_costmap_3d_ is empty the new_octree is used instead.
    */
-  virtual void checkCostmap(upgrade_lock& upgrade_lock);
+  virtual void checkCostmap(upgrade_lock& upgrade_lock,
+                            std::shared_ptr<const octomap::OcTree> new_octree = nullptr);
 
   /** @brief Update the mesh to use for queries. */
   virtual void updateMeshResource(const std::string& mesh_resource, double padding = 0.0);

--- a/costmap_3d/include/costmap_3d/costmap_3d_query.h
+++ b/costmap_3d/include/costmap_3d/costmap_3d_query.h
@@ -213,7 +213,8 @@ protected:
   virtual double calculateDistance(geometry_msgs::Pose pose,
                                    bool signed_distance = false,
                                    QueryRegion query_region = ALL,
-                                   bool reuse_past_result = false);
+                                   bool reuse_past_result = false,
+                                   bool collision_only = false);
 
 private:
   // Common initialization between all constrcutors

--- a/costmap_3d/include/costmap_3d/costmap_3d_query.h
+++ b/costmap_3d/include/costmap_3d/costmap_3d_query.h
@@ -152,7 +152,8 @@ public:
    */
   virtual double footprintDistance(geometry_msgs::Pose pose,
                                    QueryRegion query_region = ALL,
-                                   bool reuse_past_result = false);
+                                   bool reuse_past_result = false,
+                                   double relative_error = 0.05);
 
   /** @brief Return minimum signed distance to nearest costmap object.
    *
@@ -181,7 +182,8 @@ public:
    */
   virtual double footprintSignedDistance(geometry_msgs::Pose pose,
                                          QueryRegion query_region = ALL,
-                                         bool reuse_past_result = false);
+                                         bool reuse_past_result = false,
+                                         double relative_error = 0.05);
 
   /** @brief get a const reference to the padded robot mesh points being used */
   const pcl::PointCloud<pcl::PointXYZ>& getRobotMeshPoints() const {return *robot_mesh_points_;}
@@ -235,7 +237,8 @@ protected:
                                    bool signed_distance = false,
                                    QueryRegion query_region = ALL,
                                    bool reuse_past_result = false,
-                                   bool collision_only = false);
+                                   bool collision_only = false,
+                                   double relative_error = 0.05);
 
 private:
   // Common initialization between all constrcutors

--- a/costmap_3d/include/costmap_3d/costmap_3d_query.h
+++ b/costmap_3d/include/costmap_3d/costmap_3d_query.h
@@ -244,9 +244,9 @@ private:
   using FCLCollisionObjectPtr = std::shared_ptr<FCLCollisionObject>;
 
   std::shared_ptr<const octomap::OcTree> octree_ptr_;
-  FCLCollisionObjectPtr getRobotCollisionObject(const geometry_msgs::Pose& pose) const;
-  FCLCollisionObjectPtr getWorldCollisionObject(const geometry_msgs::Pose& pose,
-                                                QueryRegion query_region) const;
+  void setupFCLOctree(const geometry_msgs::Pose& pose,
+                      QueryRegion query_region,
+                      fcl::OcTree<FCLFloat>* fcl_octree_ptr) const;
 
   void padPoints(pcl::PointCloud<pcl::PointXYZ>::Ptr points, float padding)
   {

--- a/costmap_3d/include/costmap_3d/costmap_3d_ros.h
+++ b/costmap_3d/include/costmap_3d/costmap_3d_ros.h
@@ -229,13 +229,25 @@ private:
   actionlib::SimpleActionServer<GetPlanCost3DAction> get_plan_cost_action_srv_;
   ros::ServiceServer get_plan_cost_srv_;
 
+  // Because there are two entry points to the services, and because the
+  // services share buffered query maps, the octree being queries should
+  // not change mis-query. Even though the queries themselves are thread
+  // safe (for multi-threaded planners), to keep results consistent
+  // for a buffered query to a single copy of the costmap, serialize
+  // the ROS service and action server.
+  std::mutex service_mutex_;
   void getPlanCost3DActionCallback(const actionlib::SimpleActionServer<GetPlanCost3DAction>::GoalConstPtr& goal);
   bool getPlanCost3DServiceCallback(GetPlanCost3DService::Request& request, GetPlanCost3DService::Response& response);
   template <typename RequestType, typename ResponseType>
   void processPlanCost3D(RequestType& request, ResponseType& response);
+  // Should be holding the service mutex, but not the costmap mutex
+  virtual std::shared_ptr<Costmap3DQuery> getBufferedQueryForService(
+          const std::string& footprint_mesh_resource = "",
+          double padding = NAN);
 
   using QueryMap = std::map<std::pair<std::string, double>, std::shared_ptr<Costmap3DQuery>>;
   QueryMap query_map_;
+  QueryMap service_buffered_query_map_;
   using upgrade_mutex = boost::upgrade_mutex;
   using upgrade_lock = boost::upgrade_lock<upgrade_mutex>;
   using upgrade_to_unique_lock = boost::upgrade_to_unique_lock<upgrade_mutex>;

--- a/costmap_3d/include/costmap_3d/costmap_3d_ros.h
+++ b/costmap_3d/include/costmap_3d/costmap_3d_ros.h
@@ -106,6 +106,9 @@ public:
           const std::string& footprint_mesh_resource = "",
           double padding = NAN);
 
+  /** @brief update the given buffered query to hold a copy of the current costmap */
+  virtual void updateBufferedQuery(std::shared_ptr<Costmap3DQuery> query);
+
   /** @brief Get a query object associated with our layered costmap.
    * Note: it is up to the caller to ensure the costmap is properly
    * locked while executing queries, or unpredictable behavior will occur!

--- a/costmap_3d/include/costmap_3d/crop_hull.h
+++ b/costmap_3d/include/costmap_3d/crop_hull.h
@@ -38,6 +38,7 @@
 #ifndef COSTMAP_3D_PCL_CROP_HULL_H_
 #define COSTMAP_3D_PCL_CROP_HULL_H_
 
+#include <pcl/common/projection_matrix.h>
 #include <pcl/point_types.h>
 #include <pcl/Vertices.h>
 
@@ -114,7 +115,7 @@ public:
     * \param[out] indices the indices of the set of points that passed the filter.
     */
   void
-  applyFilter (const PointCloud& input, std::vector<int> &indices)
+  applyFilter (const PointCloud& input, std::vector<int> &indices) const
   {
     for (std::size_t index = 0; index < input.size(); index++)
     {

--- a/costmap_3d/include/costmap_3d/fcl_helper.h
+++ b/costmap_3d/include/costmap_3d/fcl_helper.h
@@ -1,0 +1,104 @@
+/*********************************************************************
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Badger Technologies LLC
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: C. Andy Martin
+ *********************************************************************/
+#ifndef COSTMAP_3D_FCL_HELPER_H_
+#define COSTMAP_3D_FCL_HELPER_H_
+
+#include <fcl/geometry/shape/utility.h>
+#include <pcl/point_types.h>
+#include <geometry_msgs/Pose.h>
+
+namespace costmap_3d
+{
+
+template <typename S>
+inline fcl::Transform3<S> poseToFCLTransform(const geometry_msgs::Pose& pose)
+{
+  return fcl::Transform3<S>(
+      fcl::Translation3<S>(pose.position.x, pose.position.y, pose.position.z) *
+      fcl::Quaternion<S>(pose.orientation.w,
+                         pose.orientation.x,
+                         pose.orientation.y,
+                         pose.orientation.z));
+}
+
+template <typename S>
+inline fcl::Halfspace<S> convertTriangleToHalfspace(const fcl::TriangleP<S>& triangle)
+{
+  // Find the normal for the triangle
+  fcl::Vector3<S> vec_a_b = triangle.a - triangle.b;
+  fcl::Vector3<S> vec_a_c = triangle.a - triangle.c;
+  fcl::Vector3<S> normal = vec_a_b.cross(vec_a_c).normalized();
+  S plane_distance = triangle.a.dot(normal);
+  return fcl::Halfspace<S>(normal, plane_distance);
+}
+
+// FCL does not have a box to halfspace distance function.
+// It does have a collision function, which does much of the same work, but
+// only returns a binary result.
+// The code assumes the box is not rotated, which is true of octomap boxes in
+// the fixed frame.
+template <typename S>
+inline S boxHalfspaceSignedDistance(const fcl::Box<S>& box,
+                                    const fcl::Transform3<S>& box_tf,
+                                    const fcl::Halfspace<S>& halfspace)
+{
+  fcl::Vector3<S> normal = halfspace.n;
+  fcl::Vector3<S> n_dot_d_components(
+      normal[0] * box.side[0],
+      normal[1] * box.side[1],
+      normal[2] * box.side[2]);
+  fcl::Vector3<S> n_dot_d_abs = n_dot_d_components.cwiseAbs();
+  S box_extent = 0.5 * (n_dot_d_abs[0] + n_dot_d_abs[1] + n_dot_d_abs[2]);
+  S center_distance = halfspace.signedDistance(box_tf.translation());
+  return center_distance - box_extent;
+}
+
+template <typename S>
+inline fcl::Vector3<S> convertPCLPointToFCL(const pcl::PointXYZ& p)
+{
+  return fcl::Vector3<S>(p.x, p.y, p.z);
+}
+
+template <typename S>
+inline pcl::PointXYZ convertFCLPointToPCL(const fcl::Vector3<S>& p)
+{
+  return pcl::PointXYZ(p.x(), p.y(), p.z());
+}
+
+}  // namespace costmap_3d
+
+#endif  // COSTMAP_3D_FCL_HELPER_H_

--- a/costmap_3d/include/costmap_3d/interior_collision_lut.h
+++ b/costmap_3d/include/costmap_3d/interior_collision_lut.h
@@ -1,0 +1,227 @@
+/*********************************************************************
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Badger Technologies LLC
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: C. Andy Martin
+ *********************************************************************/
+#ifndef COSTMAP_3D_INTERIOR_COLLISON_LUT_H_
+#define COSTMAP_3D_INTERIOR_COLLISON_LUT_H_
+
+#include <memory>
+#include <vector>
+
+#include <fcl/geometry/bvh/BVH_model.h>
+#include <fcl/geometry/octree/octree.h>
+#include <fcl/narrowphase/distance.h>
+#include <pcl/point_types.h>
+#include <pcl/io/vtk_lib_io.h>
+#include <costmap_3d/fcl_helper.h>
+#include <costmap_3d/crop_hull.h>
+#include <costmap_3d/octree_solver.h>
+
+namespace costmap_3d
+{
+
+template <typename S>
+class InteriorCollisionLUT
+{
+  using Mesh = fcl::BVHModel<fcl::OBBRSS<S>>;
+  using GridPoint = Eigen::Matrix<unsigned, 3, 1>;
+  using Halfspaces = std::vector<fcl::Halfspace<S>>;
+  using HalfspacesPtr = std::shared_ptr<const Halfspaces>;
+  using FCLSolver = fcl::detail::GJKSolver_libccd<S>;
+
+public:
+  // If setup ever takes too long to run on startup, its work could be
+  // deferred, or its construction could be saved to disk.
+  void setup(
+      S box_size,
+      S resolution,
+      const Mesh& mesh,
+      const CropHull<pcl::PointXYZ>& crop_hull,
+      const HalfspacesPtr& halfspaces);
+
+  S distance(
+      const fcl::Box<S>& box,
+      const fcl::Transform3<S>& box_tf,
+      const fcl::Transform3<S>& mesh_tf,
+      const fcl::Transform3<S>& inverse_mesh_tf,
+      int* mesh_triangle_id_ptr = nullptr);
+
+private:
+  inline GridPoint meshToGrid(const fcl::Vector3<S>& mesh_pt) const
+  {
+    GridPoint rv;
+    for (unsigned int i = 0; i < 3; ++i)
+    {
+      rv[i] = std::floor((mesh_pt[i] - origin_[i]) / resolution_);
+    }
+    return rv;
+  }
+  inline fcl::Vector3<S> gridToMesh(const GridPoint& grid_pt) const
+  {
+    fcl::Vector3<S> rv;
+    for (unsigned int i = 0; i < 3; ++i)
+    {
+      rv[i] = grid_pt[i] * resolution_ + origin_[i] + resolution_ / 2.0;
+    }
+    return rv;
+  }
+  inline bool gridPointInBounds(const GridPoint& grid_pt) const
+  {
+    for (unsigned int i = 0; i < 3; ++i)
+    {
+      if (grid_pt[i] < 0 || grid_pt[i] >= dimensions_[i])
+      {
+        return false;
+      }
+    }
+    return true;
+  }
+  inline size_t lutIndex(const GridPoint& grid_pt) const
+  {
+    return grid_pt[2] * dimensions_[0] * dimensions_[1] +
+        grid_pt[1] * dimensions_[0] +
+        grid_pt[0];
+  }
+  HalfspacesPtr halfspaces_;
+  fcl::Vector3<S> origin_;
+  unsigned dimensions_[3];
+  S resolution_;
+  std::vector<int> lut_;
+};
+
+template <typename S>
+void InteriorCollisionLUT<S>::setup(
+    S box_size,
+    S resolution,
+    const Mesh& mesh,
+    const CropHull<pcl::PointXYZ>& crop_hull,
+    const HalfspacesPtr& halfspaces)
+{
+  resolution_ = resolution;
+  halfspaces_ = halfspaces;
+  const fcl::Vector3<S>& min = mesh.aabb_local.min_;
+  const fcl::Vector3<S>& max = mesh.aabb_local.max_;
+  for (unsigned int i=0; i<3; ++i)
+  {
+    origin_[i] = std::floor(min[i] / resolution_) * resolution_;
+    dimensions_[i] = static_cast<unsigned>(std::floor((max[i] - origin_[i]) / resolution_)) + 1;
+  }
+  lut_.resize(dimensions_[0] * dimensions_[1] * dimensions_[2]);
+  assert(lut_.size() > 0);
+
+  FCLSolver solver;
+  OcTreeMeshSolver<FCLSolver> octree_solver(&solver);
+  fcl::DistanceRequest<S> request;
+  request.enable_nearest_points = true;
+
+  std::shared_ptr<octomap::OcTree> singleton_map(new octomap::OcTree(box_size));
+  octomap::point3d box_center(box_size/2.0, box_size/2.0, box_size/2.0);
+  singleton_map->updateNode(box_center, true);
+  fcl::Transform3<S> tf = fcl::Transform3<S>::Identity();
+  fcl::OcTree<S> fcl_singleton_map(singleton_map);
+  pcl::PointCloud<pcl::PointXYZ> singleton_cloud;
+  singleton_cloud.resize(1);
+  singleton_cloud.is_dense = true;
+  singleton_cloud.width = 1;
+  singleton_cloud.height = 1;
+  std::vector<int> indices;
+
+  GridPoint grid_pt;
+  for (grid_pt[2] = 0; grid_pt[2] < dimensions_[2]; ++grid_pt[2])
+  {
+    for (grid_pt[1] = 0; grid_pt[1] < dimensions_[1]; ++grid_pt[1])
+    {
+      for (grid_pt[0] = 0; grid_pt[0] < dimensions_[0]; ++grid_pt[0])
+      {
+        // Get the octomap occupied box centered on the origin
+        // and move the centered octomap to the given point
+        tf.translation() =
+            fcl::Vector3<S>(-box_size/2.0, -box_size/2.0, -box_size/2.0) +
+            gridToMesh(grid_pt);
+        // Check if this point is an interior point.
+        singleton_cloud.points[0] = convertFCLPointToPCL<S>(tf.translation());
+        indices.clear();
+        crop_hull.applyFilter(singleton_cloud, indices);
+        int triangle_id = -1;
+        if (indices.size() > 0)
+        {
+          // This is an interior point
+          // Now find the closest triangle ...
+          fcl::DistanceResult<S> result;
+          octree_solver.distance(
+              &fcl_singleton_map,
+              &mesh,
+              tf,
+              fcl::Transform3<S>::Identity(),
+              request,
+              &result);
+          // Save the mesh triangle index in the robot model
+          triangle_id = result.b2;
+        }
+        lut_[lutIndex(grid_pt)] = triangle_id;
+      }
+    }
+  }
+}
+
+template <typename S>
+S InteriorCollisionLUT<S>::distance(
+    const fcl::Box<S>& box,
+    const fcl::Transform3<S>& box_tf,
+    const fcl::Transform3<S>& mesh_tf,
+    const fcl::Transform3<S>& inverse_mesh_tf,
+    int* mesh_triangle_id_ptr)
+{
+  GridPoint grid_pt = meshToGrid(inverse_mesh_tf * box_tf.translation());
+  if (gridPointInBounds(grid_pt))
+  {
+    int mesh_triangle_id = lut_[lutIndex(grid_pt)];
+    if (mesh_triangle_id >= 0)
+    {
+      if (mesh_triangle_id_ptr != nullptr)
+      {
+        *mesh_triangle_id_ptr = mesh_triangle_id;
+      }
+      fcl::Halfspace<S> halfspace(fcl::transform(
+              (*halfspaces_)[mesh_triangle_id], mesh_tf));
+      return boxHalfspaceSignedDistance<S>(box, box_tf, halfspace);
+    }
+  }
+  return 0.0;
+}
+
+}  // namespace costmap_3d
+
+#endif  // COSTMAP_3D_INTERIOR_COLLISON_LUT_H_

--- a/costmap_3d/include/costmap_3d/octree_solver.h
+++ b/costmap_3d/include/costmap_3d/octree_solver.h
@@ -1,0 +1,519 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2011-2014, Willow Garage, Inc.
+ *  Copyright (c) 2014-2016, Open Source Robotics Foundation
+ *  Copyright (c) 2019-2020, Badger Technologies, LLC
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Open Source Robotics Foundation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef COSTMAP_3D_COSTMAP_MESH_DISTANCE_H
+#define COSTMAP_3D_COSTMAP_MESH_DISTANCE_H
+
+#include <vector>
+#include <limits>
+#include <functional>
+
+#include <fcl/math/bv/utility.h>
+#include <fcl/geometry/octree/octree.h>
+#include <fcl/geometry/bvh/BVH_model.h>
+#include <fcl/geometry/shape/utility.h>
+#include <fcl/geometry/shape/box.h>
+#include <fcl/narrowphase/distance_request.h>
+#include <fcl/narrowphase/distance_result.h>
+
+namespace costmap_3d
+{
+
+/** Find distance between an FCL OcTree and a mesh representing a closed volume.
+ *
+ * FCL does not currently have any API support for treating a mesh as a closed
+ * volume. For Costmap purposes, the mesh is always treated as a closed (but
+ * not necessarily convex) volume. Because of this, FCL's octree distance
+ * function will not find interior collisions and is therefore inadequate for
+ * costmap queries.
+ */
+template <typename NarrowPhaseSolver>
+class OcTreeMeshSolver
+{
+  using S = typename NarrowPhaseSolver::S;
+public:
+  // Function returning the negative penetration distance of the box into the
+  // mesh. If the box is not entirely within the mesh, this function may simply
+  // return any non-negative number. This function must always return the
+  // negative penetration distance when the entire box is inside the mesh. It
+  // is OK for it to miss casses when the box and the mesh touch, as those are
+  // handled directly by the solver traversal.  The solver needs to know when
+  // an interior collision happens (and how deep it is), but knowing that is
+  // outside of its scope. It uses this function to find out if there is an
+  // interior collision and the penetration depth.
+  //
+  // The box_to_mesh_tf must put the box into the *mesh* frame.
+  using InteriorCollisionFunction = std::function<S(const fcl::Box<S>& box,
+                                                    const fcl::Transform3<S>& box_tf,
+                                                    const fcl::Transform3<S>& mesh_tf,
+                                                    const fcl::Transform3<S>& inverse_mesh_tf,
+                                                    int* mesh_trinagle_id_ptr)>;
+  using SignedDistanceFunction = std::function<S(const fcl::Box<S>& box,
+                                                 const fcl::Transform3<S>& box_tf,
+                                                 int mesh_triangle_id,
+                                                 const fcl::Transform3<S>& mesh_tf)>;
+
+  // If interior_collision_function is given, that function is used to detect
+  // interior collisions, and to directly estimate the distance for an interior
+  // collision. This makes searching all interior collisions fast enough to
+  // find the deepest penetrating collision for calculating signed distance,
+  // and also correctly models the mesh as a closed volume.
+  // If no interior_collision_function is given, the nearest triangle to the
+  // mesh will be used.
+  // If signed_distance_function is given and doing signed distance queries,
+  // the returned distance for a collision between the mesh and the octomap
+  // will use this function to modify the distance. This can be used to model
+  // the signed distance for the boundary as a halfspace-box penetration, for
+  // instance.
+  // When doing signed distance queries, all octomap boxes that touch the mesh,
+  // or are in the volume (when interior_collision_function is given) are
+  // queried to find the deepest penetration to return as the signed distance.
+  // When doing non-signed distance, once it is known the mesh and map collide,
+  // -1.0 is immediately returned.
+  OcTreeMeshSolver(
+      const NarrowPhaseSolver* solver,
+      InteriorCollisionFunction interior_collision_function = InteriorCollisionFunction(),
+      SignedDistanceFunction signed_distance_function = SignedDistanceFunction())
+      : solver_(solver),
+        interior_collision_function_(interior_collision_function),
+        signed_distance_function_(signed_distance_function)
+  {
+  }
+
+  /** Distance between fcl OcTree and fcl BVHModel (mesh)
+   *
+   * Note: request and result must not be shared between threads.
+   */
+  template <typename BV>
+  void distance(const fcl::OcTree<S>* tree1,
+                const fcl::BVHModel<BV>* tree2,
+                const fcl::Transform3<S>& tf1,
+                const fcl::Transform3<S>& tf2,
+                const fcl::DistanceRequest<S>& request,
+                fcl::DistanceResult<S>* result) const;
+
+private:
+  const NarrowPhaseSolver* solver_;
+  InteriorCollisionFunction interior_collision_function_;
+  SignedDistanceFunction signed_distance_function_;
+  // This is only mutated when OcTreeMeshDistance is called and is used to
+  // keep from having to put the request and result on the stack for every
+  // recursive call.
+  mutable const fcl::DistanceRequest<S>* drequest_ = nullptr;
+  mutable fcl::DistanceResult<S>* dresult_ = nullptr;
+  mutable fcl::Transform3<S> mesh_tf_inverse_;
+
+  template <typename BV>
+  bool OcTreeMeshDistanceRecurse(const fcl::OcTree<S>* tree1,
+                                 const typename fcl::OcTree<S>::OcTreeNode* root1,
+                                 const fcl::AABB<S>& bv1,
+                                 const fcl::BVHModel<BV>* tree2,
+                                 int root2,
+                                 const fcl::Transform3<S>& tf2,
+                                 const std::vector<fcl::Halfspace<S>>* roi) const;
+};
+
+template <typename NarrowPhaseSolver>
+template <typename BV>
+void OcTreeMeshSolver<NarrowPhaseSolver>::distance(
+    const fcl::OcTree<S>* tree1,
+    const fcl::BVHModel<BV>* tree2,
+    const fcl::Transform3<S>& tf1,
+    const fcl::Transform3<S>& tf2,
+    const fcl::DistanceRequest<S>& request,
+    fcl::DistanceResult<S>* result) const
+{
+  drequest_ = &request;
+  dresult_ = result;
+
+  fcl::Transform3<S> mesh_tf = tf1.inverse() * tf2;
+  mesh_tf_inverse_ = mesh_tf.inverse();
+
+  OcTreeMeshDistanceRecurse(tree1,
+                            tree1->getRoot(),
+                            tree1->getRootBV(),
+                            tree2,
+                            0,
+                            mesh_tf,
+                            &tree1->getRegionOfInterest());
+}
+
+// Convenience function to find the distance from a cube (represented in aabb1) in I configuration
+// to some other bounding volume
+template <typename S, typename BV2>
+inline S distanceOctomapRSS(const fcl::AABB<S>& aabb1,
+                            const fcl::Vector3<S>& bv1_center,
+                            const BV2& bv2,
+                            const fcl::Transform3<S>& tf2,
+                            const fcl::Vector3<S>& bv2_center)
+{
+  static fcl::Matrix3<S> axis_yzx = (fcl::Matrix3<S>() << 0, 0, 1,
+                                                          1, 0, 0,
+                                                          0, 1, 0).finished();
+  static fcl::Matrix3<S> axis_zxy = (fcl::Matrix3<S>() << 0, 1, 0,
+                                                          0, 0, 1,
+                                                          1, 0, 0).finished();
+  static fcl::Matrix3<S> axis_xyz = (fcl::Matrix3<S>() << 1, 0, 0,
+                                                          0, 1, 0,
+                                                          0, 0, 1).finished();
+  // Leverage the fact that octomap cells are cubes and
+  // orient the flat face of the RSS at the current other BV
+  fcl::RSS<S> rss;
+  fcl::Vector3<S> dir(bv1_center-bv2_center);
+  dir[0] = std::abs(dir[0]);
+  dir[1] = std::abs(dir[1]);
+  dir[2] = std::abs(dir[2]);
+  const S x = aabb1.width();
+  rss.r = x / 2;
+  rss.l[0] = x;
+  rss.l[1] = x;
+  const bool x_greater_than_y = (dir[0] > dir[1]);
+  const bool y_greater_than_z = (dir[1] > dir[2]);
+  if (x_greater_than_y && y_greater_than_z)
+  {
+    rss.axis = axis_yzx;
+  }
+  else if (!(x_greater_than_y) && (y_greater_than_z))
+  {
+    rss.axis = axis_zxy;
+  }
+  else
+  {
+    rss.axis = axis_xyz;
+  }
+  rss.setToFromCenter(bv1_center);
+  return fcl::distanceBV(rss, bv2, tf2);
+}
+
+// return -1 if bv1 out of roi, 1 if in, and 0 if on.
+template <typename S>
+inline int checkROI(const fcl::AABB<S>& bv1, const std::vector<fcl::Halfspace<S>>* roi)
+{
+  fcl::Vector3<S> bv1_center = bv1.center();
+  fcl::Vector3<S> bv1_diag = bv1.max_ - bv1.min_;
+  bool all_in = true;
+
+  for (unsigned int i=0; i<roi->size(); ++i)
+  {
+    // This is performance critical code.
+    // So do not call boxHalfSpaceSignedDistance, but repeat the work here, as
+    // we do not want to spend the time to create a Box from an AABB.
+    // Also, we know that the AABB is axis-aligned with the world frame and
+    // skip rotating the halfspace normal into the boxes frame.
+    const fcl::Halfspace<S>& region((*roi)[i]);
+    fcl::Vector3<S> normal = region.n;
+    fcl::Vector3<S> n_dot_d(normal[0] * bv1_diag[0], normal[1] * bv1_diag[1], normal[2] * bv1_diag[2]);
+    fcl::Vector3<S> n_dot_d_abs = n_dot_d.cwiseAbs();
+    S bv1_extent = 0.5 * (n_dot_d_abs[0] + n_dot_d_abs[1] + n_dot_d_abs[2]);
+    S center_dist = region.signedDistance(bv1_center);
+    // If the distance from the center of the AABB in bv1 to the halfspace is
+    // bigger than the maximum extent of the AABB, the AABB is outside the
+    // boundary of the halfspace. If the negative of the center distance is
+    // bigger than the extent, the whole AABB is inside the halfspace.
+    // Otherwise, its on the boundary.
+    bool out = (center_dist > bv1_extent);
+    bool in = (-center_dist > bv1_extent);
+    if (out)
+    {
+      return -1;
+    }
+    all_in = (all_in && in);
+  }
+  if (all_in)
+  {
+    return 1;
+  }
+  return 0;
+}
+
+template <typename NarrowPhaseSolver>
+template <typename BV>
+bool OcTreeMeshSolver<NarrowPhaseSolver>::OcTreeMeshDistanceRecurse(
+    const fcl::OcTree<S>* tree1,
+    const typename fcl::OcTree<S>::OcTreeNode* root1,
+    const fcl::AABB<S>& bv1,
+    const fcl::BVHModel<BV>* tree2,
+    int root2,
+    const fcl::Transform3<S>& tf2,
+    const std::vector<fcl::Halfspace<S>>* roi) const
+{
+  // First check region of interest.
+  if (roi)
+  {
+    int rv = checkROI<S>(bv1, roi);
+    if (rv == -1)
+    {
+      // this octomap region is entirely out of the region of interest
+      return false;
+    }
+    if (rv == 1)
+    {
+      // this octomap region is entirely inside the region of interest.
+      // There is no need to check any sub-region. Null out the roi for
+      // subsequent recursive calls.
+      roi = nullptr;
+    }
+  }
+
+  if(!tree1->nodeHasChildren(root1) && tree2->getBV(root2).isLeaf())
+  {
+    if(tree1->isNodeOccupied(root1))
+    {
+      fcl::Box<S> box;
+      fcl::Transform3<S> box_tf;
+      fcl::constructBox(bv1, fcl::Transform3<S>::Identity(), box, box_tf);
+
+      int primitive_id = tree2->getBV(root2).primitiveId();
+      const fcl::Triangle& tri_id = tree2->tri_indices[primitive_id];
+      const fcl::Vector3<S>& p1 = tree2->vertices[tri_id[0]];
+      const fcl::Vector3<S>& p2 = tree2->vertices[tri_id[1]];
+      const fcl::Vector3<S>& p3 = tree2->vertices[tri_id[2]];
+
+      S dist;
+      fcl::Vector3<S> closest_p1, closest_p2;
+      solver_->shapeTriangleDistance(box, box_tf, p1, p2, p3, tf2, &dist, &closest_p1, &closest_p2);
+      dresult_->primative_distance_calculations++;
+
+      if (dist < 0.0 && drequest_->enable_signed_distance && signed_distance_function_)
+      {
+        dist = signed_distance_function_(
+            box,
+            box_tf,
+            primitive_id,
+            tf2);
+      }
+
+      if (dist < dresult_->min_distance)
+      {
+        // only allocate dynamic memory in the case where a new min was found
+        std::shared_ptr<fcl::Box<S>> box_ptr(new fcl::Box<S>(box));
+        std::shared_ptr<fcl::TriangleP<S>> triangle(new fcl::TriangleP<S>(p1, p2, p3));
+        dresult_->update(dist, tree1, tree2, root1 - tree1->getRoot(), primitive_id,
+                        closest_p1, closest_p2, box_ptr, box_tf, triangle, tf2);
+      }
+
+      return drequest_->isSatisfied(*dresult_);
+    }
+    else
+      return false;
+  }
+
+  if(!tree1->isNodeOccupied(root1)) return false;
+
+  if(tree1->nodeHasChildren(root1))
+  {
+    unsigned int nchildren = 0;
+    const typename fcl::OcTree<S>::OcTreeNode* children[8];
+    fcl::AABB<S> child_bvs[8];
+    S distances[8];
+    S min_distance = std::numeric_limits<S>::max();
+    S next_min;
+    const BV& bv2 = tree2->getBV(root2).bv;
+    const fcl::Vector3<S> bv2_center(tf2 * bv2.center());
+    for(unsigned int i = 0; i < 8; ++i)
+    {
+      if(tree1->nodeChildExists(root1, i))
+      {
+        const typename fcl::OcTree<S>::OcTreeNode* child = tree1->getNodeChild(root1, i);
+        if(tree1->isNodeOccupied(child))
+        {
+          children[nchildren] = child;
+          computeChildBV(bv1, i, child_bvs[nchildren]);
+          distances[nchildren] = distanceOctomapRSS(child_bvs[nchildren], child_bvs[nchildren].center(),
+                                                    bv2, tf2, bv2_center);
+          dresult_->bv_distance_calculations++;
+          if (distances[nchildren] < min_distance)
+          {
+            min_distance = distances[nchildren];
+          }
+          nchildren++;
+        }
+      }
+    }
+    // Visit the octree from closest to furthest and quit early when we have
+    // crossed the result min distance
+    while(min_distance < dresult_->min_distance)
+    {
+      next_min = std::numeric_limits<S>::max();
+      for(unsigned int i = 0; i < nchildren; ++i)
+      {
+        if(distances[i] == min_distance)
+        {
+          if(distances[i] < dresult_->min_distance)
+          {
+            // Possible a better result is below, descend
+            if(OcTreeMeshDistanceRecurse(tree1, children[i], child_bvs[i], tree2, root2, tf2, roi))
+              return true;
+          }
+          else
+          {
+            break;
+          }
+        }
+        else if(distances[i] > min_distance)
+        {
+          if(distances[i] < next_min)
+          {
+            next_min = distances[i];
+          }
+        }
+        else
+        {
+          // an already visited spot on a previous iteration
+        }
+      }
+      min_distance = next_min;
+    }
+  }
+  else
+  {
+    const fcl::Vector3<S> bv1_center(bv1.center());
+
+    // There is no way (that I can think of) to correctly direct the search to
+    // avoid having to test each box that touches the bounding volume of the
+    // whole mesh. So, to make it take a reasonable amount of time to check each
+    // box that is tangential to the bounding volume of the mesh (because its
+    // min_distance lower bound would be zero), create a LUT to use that takes
+    // as input the centroid of the octomap box, rounded to a grid, and looks up
+    // the mesh triangle that is closest to a box modeling that grid cell. This
+    // will give close enough results to work well for costmap queries in a
+    // reasonable amount of time. After looking up the mesh (instead of having
+    // to search for it through the BVH), the mesh triangle is modeled as a
+    // halfspace (all halfspace models can also be created at construction time)
+    // and the box to halfspace distance can be calculated (this is a fast
+    // calculation compared to a GJK run). This distance will then be used as
+    // the penetration distance.
+    //
+    // The bound distance will never be negative, clip all negatives to zero, as
+    // the overlap of bounding volumes does not give an accurate penetration
+    // depth. This forces the search to try all boxes within the mesh.
+    //
+    // The LUT and halfspaces will be pre-calculated and passed to the solver.
+    // If the solver does not have them, it will proceed normally. This way,
+    // the solver can be used to create the LUT by finding the distance
+    // between an octomap with only one cell occupied to identify the closest
+    // mesh triangle to that spot. It is outside the scope of this class how
+    // to determine if the octomap box is inside the mesh, but a method like
+    // PCL's crop hull could be used on the centroid of the mesh. This LUT
+    // mechanism does introduce some inaccuracies when the rounded centroid
+    // appears in the mesh, but is actually outside the mesh. For this reason,
+    // the LUT resolution should be more than double the octomap resolution.
+    // This can easily be achieved by using the transform argument to the
+    // distance function. Create an octomap with a single cell at the octomap
+    // index corresponding to the cell near the origin. Then provide different
+    // arguments for the transform to find the nearest mesh polygon for each
+    // entry.
+    //
+    // The LUT could also be made more accurate by taking not only position but
+    // orientation as an input. This can be abstracted at the LUT level by
+    // passing the transform to put the box into the mesh frame (this
+    // transform can be pre-calculated once for the whole distance operation).
+    // Then the LUT can decide how to find the appropriate entry.
+    if (interior_collision_function_ && root2 == 0)
+    {
+      // There is an interior collision function and we are at the root of the BVH.
+      fcl::Box<S> box;
+      fcl::Transform3<S> box_tf;
+      fcl::constructBox(bv1, fcl::Transform3<S>::Identity(), box, box_tf);
+      int primitive_id;
+      S collision_distance = interior_collision_function_(
+          box,
+          box_tf,
+          tf2,
+          mesh_tf_inverse_,
+          &primitive_id);
+      if (collision_distance < 0.0)
+      {
+        // A known interior collision.
+        const fcl::Triangle& tri_id = tree2->tri_indices[primitive_id];
+        const fcl::Vector3<S>& p1 = tree2->vertices[tri_id[0]];
+        const fcl::Vector3<S>& p2 = tree2->vertices[tri_id[1]];
+        const fcl::Vector3<S>& p3 = tree2->vertices[tri_id[2]];
+        std::shared_ptr<fcl::Box<S>> box_ptr(new fcl::Box<S>(box));
+        std::shared_ptr<fcl::TriangleP<S>> triangle(new fcl::TriangleP<S>(p1, p2, p3));
+        // Closest point doesn't make much sense on an interior collision of two volumes.
+        // Just return the center point of the box.
+        dresult_->update(collision_distance, tree1, tree2, root1 - tree1->getRoot(), primitive_id,
+                         box_tf.translation(), box_tf.translation(),
+                         box_ptr, box_tf, triangle, tf2);
+        return true;
+      }
+    }
+    int children[2] = {
+      tree2->getBV(root2).leftChild(),
+      tree2->getBV(root2).rightChild()};
+    const BV* bv2[2] = {
+      &tree2->getBV(children[0]).bv,
+      &tree2->getBV(children[1]).bv};
+    S d[2] = {
+      distanceOctomapRSS(bv1, bv1_center, *bv2[0], tf2, tf2 * bv2[0]->center()),
+      distanceOctomapRSS(bv1, bv1_center, *bv2[1], tf2, tf2 * bv2[1]->center())};
+    dresult_->bv_distance_calculations+=2;
+    // Go left first if it is closer, otherwise go right first
+    if (d[0] < d[1])
+    {
+      for (int i=0; i<2; ++i)
+      {
+        if(d[i] < dresult_->min_distance)
+        {
+          // Because we descend the octree first, there is no need to check the
+          // ROI when descending the mesh.
+          if(OcTreeMeshDistanceRecurse(tree1, root1, bv1, tree2, children[i], tf2, nullptr))
+            return true;
+        }
+      }
+    }
+    else
+    {
+      for (int i=1; i>-1; --i)
+      {
+        if(d[i] < dresult_->min_distance)
+        {
+          // Because we descend the octree first, there is no need to check the
+          // ROI when descending the mesh.
+          if(OcTreeMeshDistanceRecurse(tree1, root1, bv1, tree2, children[i], tf2, nullptr))
+            return true;
+        }
+      }
+    }
+  }
+
+  return false;
+}
+
+}  // namespace costmap_3d
+
+#endif  // COSTMAP_3D_COSTMAP_MESH_DISTANCE_H

--- a/costmap_3d/src/costmap_3d.cpp
+++ b/costmap_3d/src/costmap_3d.cpp
@@ -42,6 +42,17 @@ namespace costmap_3d
 
 Costmap3D::Costmap3D(double resolution) : octomap::OcTree(resolution)
 {
+  init();
+}
+
+Costmap3D::Costmap3D(const Costmap3D& rhs) : octomap::OcTree(rhs)
+{
+  // Be sure to init() on copy, as the octomap copy constructor does not do this
+  init();
+}
+
+void Costmap3D::init()
+{
   setProbHit(octomap::probability(LETHAL-FREE));
   setProbMiss(octomap::probability(FREE-LETHAL));
   setClampingThresMin(octomap::probability(FREE));

--- a/costmap_3d/src/costmap_3d_query.cpp
+++ b/costmap_3d/src/costmap_3d_query.cpp
@@ -434,7 +434,7 @@ bool Costmap3DQuery::footprintCollision(geometry_msgs::Pose pose, Costmap3DQuery
   // This is because our distance query correctly handles interior collisions,
   // which requires finding the nearest octomap box, which an FCL collision
   // will not do.
-  return calculateDistance(pose, false, query_region, false, true) <= 0.0;
+  return calculateDistance(pose, false, query_region, false, true, 0.0) <= 0.0;
 }
 
 // Discern if the given octomap box is an interior collision and adjust
@@ -534,7 +534,8 @@ double Costmap3DQuery::calculateDistance(geometry_msgs::Pose pose,
                                          bool signed_distance,
                                          Costmap3DQuery::QueryRegion query_region,
                                          bool reuse_past_result,
-                                         bool collision_only)
+                                         bool collision_only,
+                                         double relative_error)
 {
   upgrade_lock upgrade_lock(upgrade_mutex_);
   std::chrono::high_resolution_clock::time_point start_time = std::chrono::high_resolution_clock::now();
@@ -705,6 +706,7 @@ double Costmap3DQuery::calculateDistance(geometry_msgs::Pose pose,
   // distance query.
   upgrade_lock.unlock();
 
+  request.rel_err = relative_error;
   request.enable_nearest_points = true;
   request.enable_signed_distance = true;
 
@@ -825,16 +827,18 @@ double Costmap3DQuery::calculateDistance(geometry_msgs::Pose pose,
 
 double Costmap3DQuery::footprintDistance(geometry_msgs::Pose pose,
                                          Costmap3DQuery::QueryRegion query_region,
-                                         bool reuse_past_result)
+                                         bool reuse_past_result,
+                                         double relative_error)
 {
-  return calculateDistance(pose, false, query_region, reuse_past_result);
+  return calculateDistance(pose, false, query_region, reuse_past_result, false, relative_error);
 }
 
 double Costmap3DQuery::footprintSignedDistance(geometry_msgs::Pose pose,
                                                Costmap3DQuery::QueryRegion query_region,
-                                               bool reuse_past_result)
+                                               bool reuse_past_result,
+                                               double relative_error)
 {
-  return calculateDistance(pose, true, query_region, reuse_past_result);
+  return calculateDistance(pose, true, query_region, reuse_past_result, false, relative_error);
 }
 
 void Costmap3DQuery::checkInteriorCollisionLUT()

--- a/costmap_3d/src/costmap_3d_ros.cpp
+++ b/costmap_3d/src/costmap_3d_ros.cpp
@@ -259,7 +259,7 @@ void Costmap3DROS::resetBoundingBox(geometry_msgs::Point min, geometry_msgs::Poi
       ROS_INFO_STREAM("resetBoundingBox consider 3D layer: " << plugin_full_name <<
                       " last name: " << plugin_last_name_only);
       if (layers.find(plugin_full_name) != layers.end()
-          || plugin_last_name_only.size() > 0 && layers.find(plugin_last_name_only) != layers.end())
+          || (plugin_last_name_only.size() > 0 && layers.find(plugin_last_name_only) != layers.end()))
       {
         ROS_INFO_STREAM("resetBoundingBox 3D layer " << plugin->getName());
         plugin->resetBoundingBox(min, max);

--- a/costmap_3d/src/costmap_3d_ros.cpp
+++ b/costmap_3d/src/costmap_3d_ros.cpp
@@ -206,7 +206,25 @@ std::shared_ptr<Costmap3DQuery> Costmap3DROS::getBufferedQuery(
   const std::string& query_mesh(getFootprintMeshResource(footprint_mesh_resource));
   padding = getFootprintPadding(padding);
   std::lock_guard<LayeredCostmap3D> lock(layered_costmap_3d_);
-  return std::shared_ptr<Costmap3DQuery>(new Costmap3DQuery(layered_costmap_3d_.getCostmap3D(), query_mesh, padding));
+  std::shared_ptr<Costmap3DQuery> rv = std::shared_ptr<Costmap3DQuery>(
+      new Costmap3DQuery(layered_costmap_3d_.getCostmap3D(), query_mesh, padding));
+  rv->setLayeredCostmapUpdateNumber(layered_costmap_3d_.getNumberOfUpdates());
+  return rv;
+}
+
+void Costmap3DROS::updateBufferedQuery(std::shared_ptr<Costmap3DQuery> query)
+{
+  // Don't hold the lock while checking the update number, as that would defeat
+  // the point in having a copy of the most recent costmap. There is no need to
+  // hold the lock, as the number of updates is a simple integer, and if we miss
+  // a very recent update due to memory ordering, we will pick it up on the next
+  // cycle.
+  if (query->getLayeredCostmapUpdateNumber() != layered_costmap_3d_.getNumberOfUpdates())
+  {
+    std::lock_guard<LayeredCostmap3D> lock(layered_costmap_3d_);
+    query->setLayeredCostmapUpdateNumber(layered_costmap_3d_.getNumberOfUpdates());
+    query->updateCostmap(layered_costmap_3d_.getCostmap3D());
+  }
 }
 
 std::shared_ptr<Costmap3DQuery> Costmap3DROS::getAssociatedQuery(

--- a/costmap_3d/src/costmap_3d_ros.cpp
+++ b/costmap_3d/src/costmap_3d_ros.cpp
@@ -430,6 +430,11 @@ bool Costmap3DROS::getPlanCost3DServiceCallback(
 template <typename RequestType, typename ResponseType>
 void Costmap3DROS::processPlanCost3D(RequestType& request, ResponseType& response)
 {
+  // Serialize service calls (see comment on service_mutex_)
+  // Be sure to get this lock first so we don't delay costmap updates waiting for
+  // the service lock.
+  std::lock_guard<std::mutex> service_lock(service_mutex_);
+
   // Be sure the costmap is locked while querying, if necessary.
   std::unique_lock <LayeredCostmap3D> lock(layered_costmap_3d_, std::defer_lock);
   std::shared_ptr<Costmap3DQuery> query;
@@ -442,8 +447,8 @@ void Costmap3DROS::processPlanCost3D(RequestType& request, ResponseType& respons
 
   if (request.buffered)
   {
-    // Buffered request, getBufferedQuery gets the lock directly
-    query = getBufferedQuery(request.footprint_mesh_resource, request.padding);
+    // Buffered request, getBufferedQueryForService gets the lock directly
+    query = getBufferedQueryForService(request.footprint_mesh_resource, request.padding);
   }
   else
   {
@@ -565,6 +570,30 @@ void Costmap3DROS::processPlanCost3D(RequestType& request, ResponseType& respons
   ROS_INFO_STREAM("Finished getting " << request.poses.size() << " poses in " <<
                   (ros::Time::now() - start_time).toSec() << " seconds.");
 #endif
+}
+
+std::shared_ptr<Costmap3DQuery> Costmap3DROS::getBufferedQueryForService(
+    const std::string& footprint_mesh_resource,
+    double padding)
+{
+  const std::string& query_mesh(getFootprintMeshResource(footprint_mesh_resource));
+  padding = getFootprintPadding(padding);
+  auto query_pair = std::make_pair(query_mesh, padding);
+  // No need to lock the service_buffered_query_map_ because we must be holding
+  // the service_mutex_
+  auto query_it = service_buffered_query_map_.find(query_pair);
+  if (query_it == service_buffered_query_map_.end())
+  {
+    // Query object does not exist, create it and add it to the map
+    std::shared_ptr<Costmap3DQuery> query = getBufferedQuery(query_mesh, padding);
+    query_it = service_buffered_query_map_.insert(std::make_pair(query_pair, query)).first;
+  }
+  else
+  {
+    // Buffered query exists, update it if necessary
+    updateBufferedQuery(query_it->second);
+  }
+  return query_it->second;
 }
 
 }  // namespace costmap_3d


### PR DESCRIPTION
Fix interior collisions to always be detected.
Improve performance of the queries by allowing relative error.
Improve the interface for buffered queries to allow updating them to the latest costmap (by switching which octree they point to to a new copy of the costmap when the buffered copy is out-of-date).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/navigation/19)
<!-- Reviewable:end -->
