### PR TITLE
Navfn: Add params to weight choice of alternate goal

### DIFF
--- a/navfn/cfg/NavfnROS.cfg
+++ b/navfn/cfg/NavfnROS.cfg
@@ -20,7 +20,19 @@ gen.add("allow_unknown",
 gen.add("default_tolerance",
         double_t,
         0,
-        "A tolerance on the goal point for the planner. NavFn will attempt to create a plan that is as close to the specified goal as possible but no further than default_tolerance away.",
+        "(meters) A tolerance on the goal point for the planner. NavFn will attempt to create a plan that is as close to the specified goal as possible but no further than default_tolerance away.",
         0.0, 0.0, 10.0);
+
+gen.add("tolerance_weight_dist_from_goal",
+        double_t,
+        0,
+        "When chosing the best goal within the tolerance, weight distance of chosen point from specified goal. This weighting must be high relative to tolerance_weight_path_length or else it will fall short of the goal even when it is unobstructed.",
+        1.0, 0.0, 1000.0);
+
+gen.add("tolerance_weight_path_length",
+        double_t,
+        0,
+        "When chosing the best goal within the tolerance, weight the component of cost from the potential field value. This scales rapidly with total path length, so this weighting should be small.",
+        0.0, 0.0, 1.0);
 
 exit(gen.generate(PACKAGE, PACKAGE, "NavfnROS"))

--- a/navfn/include/navfn/navfn_ros.h
+++ b/navfn/include/navfn/navfn_ros.h
@@ -186,6 +186,8 @@ namespace navfn {
       void mapToWorld(double mx, double my, double& wx, double& wy);
       void clearRobotCell(const tf::Stamped<tf::Pose>& global_pose, unsigned int mx, unsigned int my);
       double planner_window_x_, planner_window_y_, default_tolerance_;
+      double tolerance_weight_dist_from_goal_;
+      double tolerance_weight_path_length_;
       std::string tf_prefix_;
       boost::mutex mutex_;
       ros::ServiceServer make_plan_srv_;

--- a/navfn/src/navfn_ros.cpp
+++ b/navfn/src/navfn_ros.cpp
@@ -34,6 +34,7 @@
 *
 * Author: Eitan Marder-Eppstein
 *********************************************************************/
+#include <cmath>
 #include <iomanip>
 #include <navfn/navfn_ros.h>
 #include <pluginlib/class_list_macros.h>
@@ -104,6 +105,8 @@ namespace navfn {
     (void)level;
     allow_unknown_ = config.allow_unknown;
     default_tolerance_ = config.default_tolerance;
+    tolerance_weight_dist_from_goal_ = config.tolerance_weight_dist_from_goal;
+    tolerance_weight_path_length_ = config.tolerance_weight_path_length;
     ROS_INFO_STREAM("NavfnROS Reconfig: allow_unknown: " << std::boolalpha << allow_unknown_
                     << " default_tolerance: " << default_tolerance_);
   }
@@ -307,7 +310,7 @@ namespace navfn {
     p = goal;
 
     bool found_legal = false;
-    double best_sdist = DBL_MAX;
+    double best_cost = DBL_MAX;
 
     p.pose.position.y = goal.pose.position.y - tolerance;
 
@@ -315,11 +318,15 @@ namespace navfn {
       p.pose.position.x = goal.pose.position.x - tolerance;
       while(p.pose.position.x <= goal.pose.position.x + tolerance){
         double potential = getPointPotential(p.pose.position);
-        double sdist = sq_distance(p, goal);
-        if(potential < POT_HIGH && sdist < best_sdist){
-          best_sdist = sdist;
-          best_pose = p;
-          found_legal = true;
+        if(potential < POT_HIGH){
+          double dist = std::sqrt(sq_distance(p, goal));
+          double cost = dist * tolerance_weight_dist_from_goal_
+                        + potential * tolerance_weight_path_length_;
+          if(cost < best_cost){
+            found_legal = true;
+            best_cost = cost;
+            best_pose = p;
+          }
         }
         p.pose.position.x += resolution;
       }


### PR DESCRIPTION
The existing default_tolerance allows Navfn to find the closest
reachable goal to the specified one when it is blocked. However, this
policy can cause it to choose a goal that is on the far side of the
obstacle, possibly requiring a long go-around to reach it. In some
cases, this can lead to long oscillations.

Now the cost of alternate goal is a weighted combination of its
distance to the specified goal and the length of the path required to
get to it (as represented by the potential field value at that point).

The old behavior is obtained by setting tolerance_weight_path_length to
zero (the default).

Note that tolerance_weight_dist_from_goal needs to be much larger than
tolerance_weight_path_length (on the order of 10,000 with a 0.05-meter
map resolution) in order to keep it from always choosing the
shortest-path alternate goal even when the specified goal is clear of
obstacles.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/navigation/20)
<!-- Reviewable:end -->
