### PR TITLE
costmap_3d: add nonlethal query, distance options

### DIFF
--- a/costmap_3d/action/GetPlanCost3D.action
+++ b/costmap_3d/action/GetPlanCost3D.action
@@ -39,6 +39,17 @@ uint8 COST_QUERY_REGION_RIGHT=2
 # If the region is missing for a given pose, COST_QUERY_REGION_ALL is assumed.
 uint8[] cost_query_regions
 
+# Query only lethal obstacles (default)
+uint8 COST_QUERY_OBSTACLES_LETHAL_ONLY=0
+# Query only nonlethal obstacles. Nonlethal is any cell that is between FREE and LETHAL.
+uint8 COST_QUERY_OBSTACLES_NONLETHAL_ONLY=1
+# Set to one of the above COST_QUERY_OBSTACLES_* to control what costs are
+# considered during a query. In lethal only, only lethal obstacles are
+# considered. In nonlethal only, only nonlethal (cost between FREE and LETHAL)
+# are considered. Other modes may be added to this list at a later time as they
+# are implemented.
+uint8[] cost_query_obstacles
+
 # An alternative footprint_mesh_resource to use (in base_footprint frame)
 # If empty, the default stored in the costmap will be used.
 string footprint_mesh_resource

--- a/costmap_3d/include/costmap_3d/costmap_3d.h
+++ b/costmap_3d/include/costmap_3d/costmap_3d.h
@@ -64,13 +64,19 @@ const Cost LETHAL = 10.0;
 /* A log-odds between FREE and LETHAL represents a non-lethal,
  * but greater than zero cost for that space */
 
+// Default depth for costmap octrees. This can be overriden in the constructor.
+// The default is 20 to be able to represent a large space (~5km in any
+// direction) at 1cm resolution. Increasing the depth allows larger spaces to
+// be reprsented at a slight increased CPU cost per costmap query.
+constexpr unsigned int DEFAULT_DEPTH = 20;
+
 using Costmap3DIndex = octomap::OcTreeKey;
 using Costmap3DIndexEntryType = octomap::key_type;
 
 class Costmap3D : public octomap::OcTree
 {
 public:
-  Costmap3D(double resolution);
+  Costmap3D(double resolution, unsigned int depth = DEFAULT_DEPTH);
   Costmap3D(const Costmap3D& rhs);
 
   // Return a new Costmap3D contatinaing only the nonlethal cells.

--- a/costmap_3d/include/costmap_3d/costmap_3d.h
+++ b/costmap_3d/include/costmap_3d/costmap_3d.h
@@ -56,6 +56,10 @@ typedef float Cost;
 // Sentinel. Don't choose NAN as it can't be pruned in octomap
 const Cost UNKNOWN = -200.0;
 const Cost FREE = -10.0;
+// A "nonlethal" Cost is any Cost strictly between FREE and LETHAL
+// Specifically, UNKNOWN is *not* nonlethal. Nonlethal is meant to
+// represent a sensed object that is desirable to avoid but would
+// likely be OK to collide with.
 const Cost LETHAL = 10.0;
 /* A log-odds between FREE and LETHAL represents a non-lethal,
  * but greater than zero cost for that space */
@@ -68,6 +72,14 @@ class Costmap3D : public octomap::OcTree
 public:
   Costmap3D(double resolution);
   Costmap3D(const Costmap3D& rhs);
+
+  // Return a new Costmap3D contatinaing only the nonlethal cells.
+  // This is useful for speeding up nonlethal only queries, as the tree only
+  // stores the maximum cost in the inner nodes it is impossible to cut off the
+  // searches early in the presence of lethal obstacles. This nonlethal only
+  // tree can be constructed when the costmap updates and stored and reused for
+  // all nonlethal queries.
+  std::shared_ptr<Costmap3D> nonlethalOnly() const;
 protected:
   virtual void init();
 };

--- a/costmap_3d/scripts/test_get_pose_collision_3d_in_grid.py
+++ b/costmap_3d/scripts/test_get_pose_collision_3d_in_grid.py
@@ -64,6 +64,7 @@ if __name__ == "__main__":
     x_n = 200
     y_n = 200
     regions = []
+    obstacles = []
     for i in range(x_0, x_n):
         for j in range(y_0, y_n):
             pose = geometry_msgs.msg.PoseStamped()
@@ -79,8 +80,10 @@ if __name__ == "__main__":
             pose.pose.orientation.w = q[3]
             req.poses.append(tf2_geometry_msgs.do_transform_pose(pose, xform))
             regions.append(costmap_3d.msg.GetPlanCost3DGoal.COST_QUERY_REGION_ALL)
+            obstacles.append(costmap_3d.msg.GetPlanCost3DGoal.COST_QUERY_OBSTACLES_LETHAL_ONLY)
             pose_array.poses.append(tf2_geometry_msgs.do_transform_pose(pose, xform).pose)
     req.cost_query_regions = regions
+    req.cost_query_obstacles = obstacles
 
     pose_array_pub.publish(pose_array)
 

--- a/costmap_3d/src/costmap_3d.cpp
+++ b/costmap_3d/src/costmap_3d.cpp
@@ -40,8 +40,9 @@
 namespace costmap_3d
 {
 
-Costmap3D::Costmap3D(double resolution) : octomap::OcTree(resolution)
+Costmap3D::Costmap3D(double resolution, unsigned int depth) : octomap::OcTree(resolution)
 {
+  setTreeDepth(depth);
   init();
 }
 

--- a/costmap_3d/src/costmap_3d.cpp
+++ b/costmap_3d/src/costmap_3d.cpp
@@ -71,6 +71,23 @@ void Costmap3D::init()
   // distance queries).
 }
 
+std::shared_ptr<Costmap3D> Costmap3D::nonlethalOnly() const
+{
+  std::shared_ptr<Costmap3D> out(new Costmap3D(resolution));
+  auto it = begin_leafs();
+  auto end = end_leafs();
+  while (it != end)
+  {
+    auto v = it->getLogOdds();
+    if (FREE < v && v < LETHAL)
+    {
+      out->setNodeValueAtDepth(it.getKey(), it.getDepth(), v);
+    }
+    ++it;
+  }
+  return out;
+}
+
 octomap::point3d toOctomapPoint(const geometry_msgs::Point& point)
 {
   return octomap::point3d(point.x, point.y, point.z);

--- a/costmap_3d/src/costmap_3d_ros.cpp
+++ b/costmap_3d/src/costmap_3d_ros.cpp
@@ -479,6 +479,12 @@ void Costmap3DROS::processPlanCost3D(RequestType& request, ResponseType& respons
       query_region = request.cost_query_regions[i];
     }
 
+    Costmap3DQuery::QueryObstacles query_obstacles = Costmap3DQuery::LETHAL_ONLY;
+    if (i < request.cost_query_obstacles.size())
+    {
+      query_obstacles = request.cost_query_obstacles[i];
+    }
+
     geometry_msgs::PoseStamped pose;
     float timeout_seconds = (request.transform_wait_time_limit > 0) ?
       request.transform_wait_time_limit : 0.1;
@@ -494,17 +500,20 @@ void Costmap3DROS::processPlanCost3D(RequestType& request, ResponseType& respons
       {
         pose_cost = query->footprintCollision(pose.pose, query_region) ? -1.0 : 0.0;
       }
-      else if (request.cost_query_mode == GetPlanCost3DService::Request::COST_QUERY_MODE_DISTANCE)
+      else if (request.cost_query_mode == GetPlanCost3DService::Request::COST_QUERY_MODE_COST)
       {
-        pose_cost = query->footprintDistance(pose.pose, query_region);
-      }
-      else if (request.cost_query_mode == GetPlanCost3DService::Request::COST_QUERY_MODE_SIGNED_DISTANCE)
-      {
-        pose_cost = query->footprintSignedDistance(pose.pose, query_region);
+        pose_cost = query->footprintCost(pose.pose, query_region);
       }
       else
       {
-        pose_cost = query->footprintCost(pose.pose, query_region);
+        Costmap3DQuery::DistanceOptions dopts;
+        dopts.query_region = query_region;
+        dopts.query_obstacles = query_obstacles;
+        if (request.cost_query_mode == GetPlanCost3DService::Request::COST_QUERY_MODE_SIGNED_DISTANCE)
+        {
+          dopts.signed_distance = true;
+        }
+        pose_cost = query->footprintDistance(pose.pose, dopts);
       }
     }
     else

--- a/costmap_3d/srv/GetPlanCost3DService.srv
+++ b/costmap_3d/srv/GetPlanCost3DService.srv
@@ -39,6 +39,17 @@ uint8 COST_QUERY_REGION_RIGHT=2
 # If the region is missing for a given pose, COST_QUERY_REGION_ALL is assumed.
 uint8[] cost_query_regions
 
+# Query only lethal obstacles (default)
+uint8 COST_QUERY_OBSTACLES_LETHAL_ONLY=0
+# Query only nonlethal obstacles. Nonlethal is any cell that is between FREE and LETHAL.
+uint8 COST_QUERY_OBSTACLES_NONLETHAL_ONLY=1
+# Set to one of the above COST_QUERY_OBSTACLES_* to control what costs are
+# considered during a query. In lethal only, only lethal obstacles are
+# considered. In nonlethal only, only nonlethal (cost between FREE and LETHAL)
+# are considered. Other modes may be added to this list at a later time as they
+# are implemented.
+uint8[] cost_query_obstacles
+
 # An alternative footprint_mesh_resource to use (in base_footprint frame)
 # If empty, the default stored in the costmap will be used.
 string footprint_mesh_resource


### PR DESCRIPTION
Add the ability to query nonlethal only obstacles.
A nonlethal obstacle is any Cost between FREE and LETHAL.

Also, extend the distance interface to be passed a DistanceOptions
object. This improves the interface by naming each option.

Add an option to the new interface to limit distance. This is useful
for collision checking or for limiting the distance queries

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/navigation/23)
<!-- Reviewable:end -->
