### PR TITLE
costmap_3d: add cylinder clearing layer

### DIFF
--- a/costmap_3d/CMakeLists.txt
+++ b/costmap_3d/CMakeLists.txt
@@ -38,6 +38,7 @@ include_directories(
 
 generate_dynamic_reconfigure_options(
   cfg/Costmap3D.cfg
+  cfg/CylinderClearingPlugin.cfg
   cfg/GenericPlugin.cfg
 )
 
@@ -104,6 +105,7 @@ add_library(layers_3d
   plugins/costmap_3d_to_2d_layer.cpp
   plugins/costmap_3d_to_2d_layer_3d.cpp
   plugins/static_2d_layer_3d.cpp
+  plugins/cylinder_clearing_layer_3d.cpp
 )
 
 target_link_libraries(layers_3d

--- a/costmap_3d/costmap_3d_plugins.xml
+++ b/costmap_3d/costmap_3d_plugins.xml
@@ -12,5 +12,8 @@
     <class type="costmap_3d::Static2DLayer3D" base_class_type="costmap_3d::Layer3D">
       <description>3D costmap layer that receives a static 2D map with behavior similar to costmap_2d::StaticLayer</description>
     </class>
+    <class type="costmap_3d::CylinderClearingLayer3D" base_class_type="costmap_3d::Layer3D">
+      <description>3D costmap layer that clears a cylinder from all prior layers in the stack</description>
+    </class>
   </library>
 </class_libraries>

--- a/costmap_3d/include/costmap_3d/cylinder_clearing_layer_3d.h
+++ b/costmap_3d/include/costmap_3d/cylinder_clearing_layer_3d.h
@@ -1,0 +1,93 @@
+/*********************************************************************
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, Badger Technologies LLC
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: C. Andy Martin
+ *********************************************************************/
+#ifndef COSTMAP_3D_CYLINDER_CLEARING_LAYER_3D_H_
+#define COSTMAP_3D_CYLINDER_CLEARING_LAYER_3D_H_
+
+#include <memory>
+#include <dynamic_reconfigure/server.h>
+#include <costmap_3d/CylinderClearingPluginConfig.h>
+#include <costmap_3d/layer_3d.h>
+#include <tf2_ros/transform_listener.h>
+
+namespace costmap_3d
+{
+
+class CylinderClearingLayer3D : public Layer3D
+{
+  using super = Layer3D;
+public:
+  CylinderClearingLayer3D() { current_ = true; }
+  virtual ~CylinderClearingLayer3D() = default;
+
+  virtual void initialize(LayeredCostmap3D* parent, std::string name, tf::TransformListener *tf);
+
+  virtual void updateBounds(const geometry_msgs::Pose robot_pose,
+                            const geometry_msgs::Point& rolled_min,
+                            const geometry_msgs::Point& rolled_max,
+                            Costmap3D* bounds_map);
+
+  virtual void updateCosts(const Costmap3D& bounds_map, Costmap3D* master_map);
+
+  /** @brief Deactivate this layer, no longer clearing.
+   */
+  virtual void deactivate();
+
+  /** @brief Activate this layer, clearing the cylinder. */
+  virtual void activate();
+
+  virtual void reset();
+
+  virtual void resetBoundingBox(geometry_msgs::Point min_point, geometry_msgs::Point max_point);
+
+  virtual void matchSize(const geometry_msgs::Point& min, const geometry_msgs::Point& max, double resolution);
+
+protected:
+  virtual void reconfigureCallback(costmap_3d::CylinderClearingPluginConfig &config, uint32_t level);
+
+  ros::NodeHandle pnh_;
+  std::shared_ptr<dynamic_reconfigure::Server<costmap_3d::CylinderClearingPluginConfig>> dsrv_;
+  bool enabled_ = false;
+  bool active_ = false;
+  double radius_ = 0.0;
+  double min_z_ = 0.0;
+  double max_z_ = 2.0;
+  Costmap3DPtr clearing_bounds_map_;
+};
+
+}  // namespace costmap_3d
+
+#endif  // COSTMAP_3D_POINT_CLOUD_LAYER_3D_H_

--- a/costmap_3d/plugins/cylinder_clearing_layer_3d.cpp
+++ b/costmap_3d/plugins/cylinder_clearing_layer_3d.cpp
@@ -1,0 +1,217 @@
+/*********************************************************************
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, Badger Technologies LLC
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: C. Andy Martin
+ *********************************************************************/
+#include <costmap_3d/cylinder_clearing_layer_3d.h>
+
+#include <memory>
+#include <cmath>
+
+#include <pluginlib/class_list_macros.h>
+
+PLUGINLIB_EXPORT_CLASS(costmap_3d::CylinderClearingLayer3D, costmap_3d::Layer3D)
+
+namespace costmap_3d
+{
+
+void CylinderClearingLayer3D::initialize(LayeredCostmap3D* parent, std::string name, tf::TransformListener *tf)
+{
+  super::initialize(parent, name, tf);
+
+  // Get names of topics and servers from parameter server
+  pnh_ = ros::NodeHandle("~/" + name);
+
+  ROS_INFO_STREAM("CylinderClearingLayer3D " << name << ": initializing");
+
+  dsrv_.reset(new dynamic_reconfigure::Server<costmap_3d::CylinderClearingPluginConfig>(pnh_));
+  dsrv_->setCallback(std::bind(&CylinderClearingLayer3D::reconfigureCallback, this,
+                               std::placeholders::_1, std::placeholders::_2));
+
+  activate();
+}
+
+void CylinderClearingLayer3D::reconfigureCallback(costmap_3d::CylinderClearingPluginConfig &config, uint32_t level)
+{
+  std::lock_guard<Layer3D> lock(*this);
+  enabled_ = config.enabled;
+  radius_ = config.radius;
+  radius_ = std::abs(radius_);
+  ROS_INFO_STREAM("  radius: " << radius_);
+  if (radius_ == 0.0)
+  {
+    ROS_WARN_STREAM("Radius is zero, this layer is effectively disabled");
+  }
+}
+
+void CylinderClearingLayer3D::updateBounds(
+    const geometry_msgs::Pose robot_pose,
+    const geometry_msgs::Point& rolled_min,
+    const geometry_msgs::Point& rolled_max,
+    Costmap3D* bounds_map)
+{
+  std::lock_guard<Layer3D> lock(*this);
+  if (clearing_bounds_map_)
+  {
+    // Always add the last clearing bounds into this bounds map so upstream
+    // layers can copy data back in we removed in previous cycle(s). Our clearing
+    // bounds map each cycle only includes what was inside the cylinder, so this
+    // is not too much added burden.
+    bounds_map->setTreeValues(clearing_bounds_map_.get(), true, false);
+  }
+  if (active_ && enabled_)
+  {
+    clearing_bounds_map_ = std::make_shared<Costmap3D>(bounds_map->getResolution());
+
+    // Find bounding box of cylinder
+    Costmap3DIndex min_index;
+    Costmap3DIndex max_index;
+    bounds_map->coordToKeyClamped(
+        robot_pose.position.x - radius_,
+        robot_pose.position.y - radius_,
+        min_z_,
+        min_index);
+    bounds_map->coordToKeyClamped(
+        robot_pose.position.x + radius_,
+        robot_pose.position.y + radius_,
+        max_z_,
+        max_index);
+
+    // Loop over 2D space to find octomap cells inside the cylinder footprint
+    Costmap3DIndex index;
+    double robot_x = robot_pose.position.x;
+    double robot_y = robot_pose.position.y;
+    double r_squared = radius_ * radius_;
+    for (index[0] = min_index[0]; index[0] <= max_index[0]; ++index[0])
+    {
+      for (index[1] = min_index[1]; index[1] <= max_index[1]; ++index[1])
+      {
+        // Just consider the center of the cell for the radius check.
+        const double x = bounds_map->keyToCoord(index[0]) - robot_x;
+        const double y = bounds_map->keyToCoord(index[1]) - robot_y;
+        if (x * x + y * y <= r_squared)
+        {
+          // This cell is in the cylinder, so add all z-values to the clearing bounds
+          for (index[2] = min_index[2]; index[2] <= max_index[2]; ++index[2])
+          {
+            clearing_bounds_map_->setNodeValue(index, LETHAL);
+          }
+        }
+      }
+    }
+    // Be sure everything we want to delete this cycle is also in the bounds map
+    bounds_map->setTreeValues(clearing_bounds_map_.get(), true, false);
+  }
+  else
+  {
+    // Either inactive or disabled, clear out the clearing bounds map as we are
+    // no longer deleting other layer's data.
+    clearing_bounds_map_.reset();
+  }
+}
+
+void CylinderClearingLayer3D::updateCosts(const Costmap3D& bounds_map, Costmap3D* master_map)
+{
+  std::lock_guard<Layer3D> lock(*this);
+  if (active_ && enabled_ && clearing_bounds_map_)
+  {
+    // Clear (erase) any upstream map data in the clearing bounds map
+    master_map->setTreeValues(nullptr, clearing_bounds_map_.get(), false, true);
+  }
+}
+
+void CylinderClearingLayer3D::deactivate()
+{
+  std::lock_guard<Layer3D> lock(*this);
+  active_ = false;
+}
+
+void CylinderClearingLayer3D::activate()
+{
+  std::lock_guard<Layer3D> lock(*this);
+  active_ = true;
+}
+
+void CylinderClearingLayer3D::reset()
+{
+  std::lock_guard<Layer3D> lock(*this);
+  // No longer need to remember previous clearing bounds, as a reset will force
+  // all data from other layers to be re-copied.
+  clearing_bounds_map_.reset();
+}
+
+void CylinderClearingLayer3D::resetBoundingBox(
+    geometry_msgs::Point min_point,
+    geometry_msgs::Point max_point)
+{
+  std::lock_guard<Layer3D> lock(*this);
+  if (clearing_bounds_map_)
+  {
+    // No longer need to remember which cells we have deleted inside this
+    // bounding box, as layers above will have to recopy their data.
+    Costmap3DIndex min_index;
+    Costmap3DIndex max_index;
+    clearing_bounds_map_->coordToKeyClamped(
+        min_point.x,
+        min_point.y,
+        min_point.z,
+        min_index);
+    clearing_bounds_map_->coordToKeyClamped(
+        max_point.x,
+        max_point.y,
+        max_point.z,
+        max_index);
+    clearing_bounds_map_->deleteAABB(min_index, max_index);
+  }
+}
+
+void CylinderClearingLayer3D::matchSize(
+    const geometry_msgs::Point& min,
+    const geometry_msgs::Point& max,
+    double resolution)
+{
+  std::lock_guard<Layer3D> lock(*this);
+  min_z_ = min.z;
+  max_z_ = max.z;
+  if (clearing_bounds_map_ &&
+      resolution > 0.0 &&
+      resolution != clearing_bounds_map_->getResolution())
+  {
+    // On a resolution change, all layers have to re-copy their data. There is
+    // no need to remember what cells we have deleted in the past.
+    clearing_bounds_map_.reset();
+  }
+}
+
+}  // namespace costmap_3d


### PR DESCRIPTION
Add new 3D costmap layer which clears (deletes) any data within a
cylinder around the robot added by previous layers.  This is useful
to implement footprint clearing for global costmaps, which is in turn
useful for global planning in the presence of sensor noise or static
map noise. Because many global planners will operate only on the
resulting 2D map, cylinder clearing is sufficient for many costmap
configurations, and is simple to implement.

The cylinder clearing layer only clears out data from layers above
it, and only by overriding it temporarily. When the robot moves and
uncovers the deleted spot, the old data will be copied back by
forcing it in the bounds map.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/navigation/26)
<!-- Reviewable:end -->
