### PR TITLE
costmap_3d: make CostmapLayer3D pure virtual

### DIFF
--- a/costmap_3d/include/costmap_3d/costmap_layer_3d.h
+++ b/costmap_3d/include/costmap_3d/costmap_layer_3d.h
@@ -53,7 +53,7 @@ class CostmapLayer3D : public Layer3D
   using super = Layer3D;
 public:
   CostmapLayer3D();
-  virtual ~CostmapLayer3D();
+  virtual ~CostmapLayer3D() = 0;
 
   /** @brief Add nodes to bounds_map for any cells that have changed
    *

--- a/costmap_3d/include/costmap_3d/layer_3d.h
+++ b/costmap_3d/include/costmap_3d/layer_3d.h
@@ -56,7 +56,7 @@ class Layer3D
 {
 public:
   Layer3D();
-  virtual ~Layer3D();
+  virtual ~Layer3D() = 0;
 
   /** @brief Add nodes to bounds_map for any cells that have changed
    *


### PR DESCRIPTION
CostmapLayer3D was never meant to be instantiated. Make it pure
virtual by marking its destructor as null.

Also mark Layer3D's destructor null for completeness.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/navigation/31)
<!-- Reviewable:end -->
