### PR TITLE
costmap_2d: always update master map internal bounds

### DIFF
--- a/costmap_2d/src/layered_costmap.cpp
+++ b/costmap_2d/src/layered_costmap.cpp
@@ -126,7 +126,13 @@ void LayeredCostmap::updateMap(double robot_x, double robot_y, double robot_yaw)
   ROS_DEBUG("Updating area x: [%d, %d] y: [%d, %d]", x0, xn, y0, yn);
 
   if (xn < x0 || yn < y0)
+  {
+    bx0_ = x0;
+    bxn_ = xn;
+    by0_ = y0;
+    byn_ = yn;
     return;
+  }
 
   costmap_.resetMap(x0, y0, xn, yn);
   for (vector<boost::shared_ptr<Layer> >::iterator plugin = plugins_.begin(); plugin != plugins_.end();


### PR DESCRIPTION
Always update the stored internal master map bounds on any update.
Previously, the bounds were only saved if there was a change.
This means that if the map did *not* change, the costmap publisher
will mistakenly use the old bounds. This is a big issue on large
maps which change seldomly (such as a static_map only costmap), as
they will publish updates containing the entire map when nothing
changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/navigation/32)
<!-- Reviewable:end -->
