### PR TITLE
navfn: do not clear the robot cell

### DIFF
--- a/navfn/src/navfn_ros.cpp
+++ b/navfn/src/navfn_ros.cpp
@@ -196,16 +196,6 @@ namespace navfn {
     return planner_->calcNavFnDijkstra();
   }
 
-  void NavfnROS::clearRobotCell(const tf::Stamped<tf::Pose>& global_pose, unsigned int mx, unsigned int my){
-    if(!initialized_){
-      ROS_ERROR("This planner has not been initialized yet, but it is being used, please call initialize() before use");
-      return;
-    }
-
-    //set the associated costs in the cost map to be free
-    costmap_->setCost(mx, my, costmap_2d::FREE_SPACE);
-  }
-
   bool NavfnROS::makePlanService(nav_msgs::GetPlan::Request& req, nav_msgs::GetPlan::Response& resp){
     makePlan(req.start, req.goal, resp.plan.poses);
 
@@ -259,11 +249,6 @@ namespace navfn {
       ROS_WARN("The robot's start position is off the global costmap. Planning will always fail, are you sure the robot has been properly localized?");
       return false;
     }
-
-    //clear the starting cell within the costmap because we know it can't be an obstacle
-    tf::Stamped<tf::Pose> start_pose;
-    tf::poseStampedMsgToTF(start, start_pose);
-    clearRobotCell(start_pose, mx, my);
 
 #if 0
     {


### PR DESCRIPTION
It is incorrect to clear the "robot cell" as the planner may be
called with some future position for the starting pose of the plan.
Also, clearing just one cell does not handle clearing the entire
footprint. Footprint clearing is outside the scope of the planner
and belongs in the costmap itself.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/navigation/34)
<!-- Reviewable:end -->
