### PR TITLE
Ray query

### DIFF
--- a/costmap_3d/CMakeLists.txt
+++ b/costmap_3d/CMakeLists.txt
@@ -49,11 +49,13 @@ generate_dynamic_reconfigure_options(
 add_action_files(
   FILES
   GetPlanCost3D.action
+  RayQuery3D.action
 )
 
 add_service_files(
   FILES
   GetPlanCost3DService.srv
+  RayQuery3DService.srv
 )
 
 generate_messages(
@@ -151,4 +153,8 @@ install(FILES
 
 install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+)
+
+install(DIRECTORY meshes
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )

--- a/costmap_3d/action/GetPlanCost3D.action
+++ b/costmap_3d/action/GetPlanCost3D.action
@@ -35,6 +35,11 @@ uint8 COST_QUERY_REGION_ALL=0
 uint8 COST_QUERY_REGION_LEFT=1
 # Query the map only to the right of each query pose.
 uint8 COST_QUERY_REGION_RIGHT=2
+# Query a 1m by 1m rectangular prism starting at the origin of each pose.
+# To alter the size of the prism in the frame of the pose, scale the
+# pose's quaternion appropriately to scale the prism when it is transformed.
+# To scale the width differently from the height, use the ray query interface.
+uint8 COST_QUERY_REGION_RECTANGULAR_PRISM=3
 # Set to one of the above COST_QUERY_REGION_* to control query region per pose.
 # If the region is missing for a given pose, COST_QUERY_REGION_ALL is assumed.
 uint8[] cost_query_regions

--- a/costmap_3d/action/RayQuery3D.action
+++ b/costmap_3d/action/RayQuery3D.action
@@ -1,0 +1,29 @@
+# Get the distances to nearest occupied voxel on rectangular prismatic rays.
+# For each ray pose, the rectangular prism is assumed to be originated at (0,
+# 0, 0) and oriented along the x-axis with the width on the y-axis and the
+# height on the z-axis.
+Header header
+
+# Rays to query. The prism is transformed using each pose into
+# header.frame_id at time header.stamp, and then into the fixed frame of the
+# costmap to perform the query. Essentially, each ray pose defines a temporary
+# frame of reference for the rectangular prism for each query ray.
+geometry_msgs/Pose[] ray_poses
+
+# Width of rectangular prism query region in meters.
+float64 width
+
+# Height of rectangular prism query region in meters.
+float64 height
+
+# The maximum amount of time (seconds) to wait for a transform to become
+# available to transform a pose. (default=0.1, any values <= 0 will be
+# converted to the default.)
+float32 transform_wait_time_limit
+---
+# The distance from the origin of each ray pose to the nearest costmap voxel
+# inside the region of interest defined by the rectangular prism.
+# If no voxel was found, the distance will be +inf.
+float64[] distances
+---
+# no feedback

--- a/costmap_3d/cfg/Costmap3D.cfg
+++ b/costmap_3d/cfg/Costmap3D.cfg
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from dynamic_reconfigure.parameter_generator_catkin import ParameterGenerator, double_t, int_t, str_t
+from dynamic_reconfigure.parameter_generator_catkin import ParameterGenerator, double_t, bool_t
 
 gen = ParameterGenerator()
 
@@ -10,5 +10,7 @@ gen.add("map_z_max", double_t, 0, "The height (maximum z) of the map in meters."
 
 # robot 3d footprint
 gen.add("footprint_3d_padding", double_t, 0, "How much to pad (increase the size of) the 3D footprint, in meters.", 0.01)
+
+gen.add("visualize_ray_query_miss", bool_t, 0, "Whether missed ray queries should be visualized.", True)
 
 exit(gen.generate("costmap_3d", "costmap_3d", "Costmap3D"))

--- a/costmap_3d/include/costmap_3d/costmap_3d_query.h
+++ b/costmap_3d/include/costmap_3d/costmap_3d_query.h
@@ -67,6 +67,8 @@ namespace costmap_3d
 class Costmap3DQuery
 {
 public:
+  using QueryRegionScale = Eigen::Vector3d;
+
   /**
    * @brief  Construct a query object associated with a layered costmap 3D.
    * The query will always be performed on the current layered costmap 3D,
@@ -76,6 +78,7 @@ public:
       const LayeredCostmap3D* layered_costmap_3d,
       const std::string& mesh_resource,
       double padding = 0.0,
+      Costmap3DQuery::QueryRegionScale = Costmap3DQuery::QueryRegionScale::Zero(),
       unsigned int pose_bins_per_meter = 4,
       unsigned int pose_bins_per_radian = 4,
       unsigned int pose_milli_bins_per_meter = 20,
@@ -96,6 +99,7 @@ public:
       const Costmap3DConstPtr& costmap_3d,
       const std::string& mesh_resource,
       double padding = 0.0,
+      Costmap3DQuery::QueryRegionScale = Costmap3DQuery::QueryRegionScale::Zero(),
       unsigned int pose_bins_per_meter = 4,
       unsigned int pose_bins_per_radian = 4,
       unsigned int pose_milli_bins_per_meter = 20,
@@ -110,7 +114,8 @@ public:
   static constexpr QueryRegion ALL = GetPlanCost3DService::Request::COST_QUERY_REGION_ALL;
   static constexpr QueryRegion LEFT = GetPlanCost3DService::Request::COST_QUERY_REGION_LEFT;
   static constexpr QueryRegion RIGHT = GetPlanCost3DService::Request::COST_QUERY_REGION_RIGHT;
-  static constexpr QueryRegion MAX = RIGHT+1;
+  static constexpr QueryRegion RECTANGULAR_PRISM = GetPlanCost3DService::Request::COST_QUERY_REGION_RECTANGULAR_PRISM;
+  static constexpr QueryRegion MAX = RECTANGULAR_PRISM+1;
 
   /// What kind of obstacles to consider for the query.
   using QueryObstacles = uint8_t;
@@ -222,6 +227,16 @@ public:
   /** @brief get a const reference to the mesh polygons being used */
   const std::vector<pcl::Vertices>& getRobotMeshPolygons() const {return robot_mesh_.polygons;}
 
+  /** @brief Set scale for query region.
+   *
+   * Some query regions have a scaling vector, such as rectangular prism.
+   * It is more efficient to set the scaling per-query object in most cases.
+   * This method must hold the internal lock, so this interface is not useful
+   * for parallel queries. In such cases, use the DistanceOptions to set the
+   * scale per queried pose.
+   */
+  void setQueryRegionDefaultScale(QueryRegionScale default_scale);
+
   /** @brief set the layered costmap update number.
    *
    * This is useful for buffered queries to store which costmap update they represent.
@@ -311,9 +326,8 @@ private:
   // efficient way to query nonlethal. Fix this by making a copy of the octree
   // when the first nonlethal query is issued to use for nonlethal queries.
   std::shared_ptr<const octomap::OcTree> nonlethal_octree_ptr_;
-  void setupFCLOctree(const geometry_msgs::Pose& pose,
-                      QueryRegion query_region,
-                      fcl::OcTree<FCLFloat>* fcl_octree_ptr) const;
+
+  QueryRegionScale query_region_scale_;
 
   void padPoints(pcl::PointCloud<pcl::PointXYZ>::Ptr points, float padding)
   {
@@ -549,6 +563,96 @@ private:
     fcl::Transform3<FCLFloat> octomap_box_tf;
     std::shared_ptr<fcl::TriangleP<FCLFloat>> mesh_triangle;
     int mesh_triangle_id;
+  };
+  // Internal class to decompose a region of interst into a set of halfspaces.
+  // Because this internal class is used on the fast-paths, avoid dynamic memory.
+  class RegionsOfInterestAtPose
+  {
+  public:
+    // Construct a region of interst at a pose. Internally store the set of halfspaces.
+    RegionsOfInterestAtPose(QueryRegion query_region, const QueryRegionScale& query_region_scale, const geometry_msgs::Pose& pose)
+    {
+      if (query_region == LEFT || query_region == RIGHT)
+      {
+        constexpr unsigned int NUM_ROIS = 1;
+        static_assert(NUM_ROIS <= ROIS_CAPACITY, "ROIS_CAPACITY is too small, increase to match NUM_ROIS");
+        rois_size_ = NUM_ROIS;
+        fcl::Vector3<FCLFloat> normal;
+        // Note, for FCL halfspaces, the inside space is that below the plane, so
+        // the normal needs to point away from the query region
+        if (query_region == LEFT)
+        {
+          normal << 0.0, -1.0, 0.0;
+        }
+        else if(query_region == RIGHT)
+        {
+          normal << 0.0, 1.0, 0.0;
+        }
+        rois_[0] = fcl::transform(fcl::Halfspace<FCLFloat>(normal, 0.0), poseToFCLTransform<FCLFloat>(pose));
+      }
+      else if (query_region == RECTANGULAR_PRISM)
+      {
+        constexpr unsigned int NUM_ROIS = 5;
+        static_assert(NUM_ROIS <= ROIS_CAPACITY, "ROIS_CAPACITY is too small, increase to match NUM_ROIS");
+        rois_size_ = NUM_ROIS;
+        fcl::Vector3<FCLFloat> normals[NUM_ROIS] = {
+            fcl::Vector3<FCLFloat>(-1.0, 0.0, 0.0),
+            fcl::Vector3<FCLFloat>(0.0, 1.0, 0.0),
+            fcl::Vector3<FCLFloat>(0.0, -1.0, 0.0),
+            fcl::Vector3<FCLFloat>(0.0, 0.0, 1.0),
+            fcl::Vector3<FCLFloat>(0.0, 0.0, -1.0),
+        };
+        FCLFloat distances[NUM_ROIS] = {
+            0.0,
+            query_region_scale(1) / 2.0,
+            query_region_scale(1) / 2.0,
+            query_region_scale(2) / 2.0,
+            query_region_scale(2) / 2.0,
+        };
+        const auto fcl_xform = poseToFCLTransform<FCLFloat>(pose);
+        for (unsigned int i = 0; i < NUM_ROIS; ++i)
+        {
+          rois_[i] = fcl::transform(fcl::Halfspace<FCLFloat>(normals[i], distances[i]), fcl_xform);
+        }
+      }
+      assert(rois_size_ <= ROIS_CAPACITY);
+    }
+    // Test if the given distance cache entry is inside the region.
+    // Regions are always inclusive. A voxel on the region boundary is
+    // considered "inside".
+    bool distanceCacheEntryInside(const DistanceCacheEntry& cache_entry)
+    {
+      const auto& box = *(cache_entry.octomap_box);
+      const auto& box_tf = cache_entry.octomap_box_tf;
+
+      for (unsigned int i = 0; i < rois_size_; ++i)
+      {
+        if (costmap_3d::boxHalfspaceSignedDistance<FCLFloat>(box, box_tf, rois_[i]) > 0)
+        {
+          return false;
+        }
+      }
+      // In or on each halfspace
+      return true;
+    }
+    // Apply this region to the FCL octree by copying the halfspaces into the
+    // FCL octree class.
+    void setupFCLOctree(fcl::OcTree<FCLFloat>* fcl_octree_ptr) const
+    {
+      for (unsigned int i = 0; i < rois_size_; ++i)
+      {
+        fcl_octree_ptr->addToRegionOfInterest(rois_[i]);
+      }
+    }
+  private:
+    unsigned int rois_size_ = 0;
+    // To avoid dynamic memory allocation use a fixed-size array.
+    // This is an added point of maintenance, but is necessary for optimum
+    // query performance. If a new region is added that requires more than
+    // the current number of regions, ROIS_CAPACITY must also be changed
+    // to match.
+    static constexpr unsigned int ROIS_CAPACITY = 5;
+    fcl::Halfspace<FCLFloat> rois_[ROIS_CAPACITY];
   };
   // used by distance calculation to find interior collisions
   double handleDistanceInteriorCollisions(

--- a/costmap_3d/include/costmap_3d/costmap_3d_ros.h
+++ b/costmap_3d/include/costmap_3d/costmap_3d_ros.h
@@ -230,8 +230,8 @@ private:
   ros::ServiceServer get_plan_cost_srv_;
 
   // Because there are two entry points to the services, and because the
-  // services share buffered query maps, the octree being queries should
-  // not change mis-query. Even though the queries themselves are thread
+  // services share buffered query maps, the octree being queried should
+  // not change mid-query. Even though the queries themselves are thread
   // safe (for multi-threaded planners), to keep results consistent
   // for a buffered query to a single copy of the costmap, serialize
   // the ROS service and action server.

--- a/costmap_3d/include/costmap_3d/costmap_3d_ros.h
+++ b/costmap_3d/include/costmap_3d/costmap_3d_ros.h
@@ -41,6 +41,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <tuple>
 #include <ros/ros.h>
 #include <actionlib/server/simple_action_server.h>
 #include <costmap_2d/costmap_2d_ros.h>
@@ -49,6 +50,8 @@
 #include <costmap_3d/costmap_3d_query.h>
 #include <costmap_3d/GetPlanCost3DAction.h>
 #include <costmap_3d/GetPlanCost3DService.h>
+#include <costmap_3d/RayQuery3DAction.h>
+#include <costmap_3d/RayQuery3DService.h>
 #include <costmap_3d/Costmap3DConfig.h>
 #include <dynamic_reconfigure/server.h>
 #include <pluginlib/class_loader.h>
@@ -225,9 +228,13 @@ private:
   pluginlib::ClassLoader<Layer3D> plugin_loader_;
   Costmap3DPublisher publisher_;
   ros::Publisher footprint_pub_;
+  bool visualize_ray_query_miss_ = true;
+  ros::Publisher ray_query_3d_visualization_pub_;
   dynamic_reconfigure::Server<costmap_3d::Costmap3DConfig> dsrv_;
   actionlib::SimpleActionServer<GetPlanCost3DAction> get_plan_cost_action_srv_;
   ros::ServiceServer get_plan_cost_srv_;
+  actionlib::SimpleActionServer<RayQuery3DAction> ray_query_action_srv_;
+  ros::ServiceServer ray_query_srv_;
 
   // Because there are two entry points to the services, and because the
   // services share buffered query maps, the octree being queried should
@@ -245,7 +252,54 @@ private:
           const std::string& footprint_mesh_resource = "",
           double padding = NAN);
 
-  using QueryMap = std::map<std::pair<std::string, double>, std::shared_ptr<Costmap3DQuery>>;
+  void rayQuery3DActionCallback(const actionlib::SimpleActionServer<RayQuery3DAction>::GoalConstPtr& goal);
+  bool rayQuery3DServiceCallback(RayQuery3DService::Request& request, RayQuery3DService::Response& response);
+  template <typename RequestType, typename ResponseType>
+  bool processRayQuery3D(RequestType& request, ResponseType& response);
+
+  using QueryMapKey = std::tuple<std::string, double, Costmap3DQuery::QueryRegionScale>;
+  // std::less does not work on Eigen3 vectors, so use this comparator.
+  struct QueryMapKeyCompare
+  {
+    bool operator()(const QueryMapKey& lhs, const QueryMapKey& rhs)
+    {
+      const auto& lhs0 = std::get<0>(lhs);
+      const auto& lhs1 = std::get<1>(lhs);
+      const auto& lhs2 = std::get<2>(lhs);
+      const auto& rhs0 = std::get<0>(rhs);
+      const auto& rhs1 = std::get<1>(rhs);
+      const auto& rhs2 = std::get<2>(rhs);
+      if (lhs0 < rhs0)
+      {
+        return true;
+      }
+      if (lhs0 > rhs0)
+      {
+        return false;
+      }
+      if (lhs1 < rhs1)
+      {
+        return true;
+      }
+      if (lhs1 > rhs1)
+      {
+        return false;
+      }
+      for (unsigned int i=0; i<3; ++i)
+      {
+        if (lhs2(i) < rhs2(i))
+        {
+          return true;
+        }
+        if (lhs2(i) > rhs2(i))
+        {
+          return false;
+        }
+      }
+      return false;
+    }
+  };
+  using QueryMap = std::map<QueryMapKey, std::shared_ptr<Costmap3DQuery>, QueryMapKeyCompare>;
   QueryMap query_map_;
   QueryMap service_buffered_query_map_;
   using upgrade_mutex = boost::upgrade_mutex;
@@ -256,8 +310,18 @@ private:
   const std::string& getFootprintMeshResource(const std::string& alt_mesh);
   double getFootprintPadding(double alt_padding);
   // assumes costmap is locked
-  std::shared_ptr<Costmap3DQuery> getQuery(const std::string& footprint_mesh_resource, double padding);
+  std::shared_ptr<Costmap3DQuery> getQuery(
+      const std::string& footprint_mesh_resource,
+      double padding,
+      Costmap3DQuery::QueryRegionScale query_region_scale = Costmap3DQuery::QueryRegionScale::Zero(),
+      unsigned int pose_bins_per_meter = 4,
+      unsigned int pose_bins_per_radian = 4,
+      unsigned int pose_milli_bins_per_meter = 20,
+      unsigned int pose_milli_bins_per_radian = 20,
+      unsigned int pose_micro_bins_per_meter = 1024,
+      unsigned int pose_micro_bins_per_radian = 1024);
   void publishFootprint();
+  void publishRegionOfInterest(std::shared_ptr<Costmap3DQuery> query, const geometry_msgs::PoseStamped& query_pose);
 
   std::string footprint_mesh_resource_;
   double footprint_3d_padding_;

--- a/costmap_3d/meshes/point.stl
+++ b/costmap_3d/meshes/point.stl
@@ -1,0 +1,9 @@
+solid point
+    facet normal 1.00000E+000 0.00000E+000 0.00000E+000
+        outer loop
+            vertex 0.00000E+000 0.00000E+000 0.00000E+000
+            vertex 0.00000E+000 1.00000E-012 0.00000E+000
+            vertex 0.00000E+000 0.00000E+000 1.00000E-012
+        endloop
+    endfacet
+endsolid point

--- a/costmap_3d/scripts/ray_query_3d.py
+++ b/costmap_3d/scripts/ray_query_3d.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+"""
+Test ray query 3D
+"""
+
+import sys
+import rospy
+import math
+import tf.transformations
+import costmap_3d.srv
+import geometry_msgs.msg
+import copy
+
+
+if __name__ == "__main__":
+    x = 0
+    if len(sys.argv) > 1:
+        x = float(sys.argv[1])
+    y = 0
+    if len(sys.argv) > 2:
+        y = float(sys.argv[2])
+    z = 0
+    if len(sys.argv) > 3:
+        z = float(sys.argv[3])
+    roll = 0
+    if len(sys.argv) > 4:
+        roll = float(sys.argv[4])
+    pitch = 0
+    if len(sys.argv) > 5:
+        pitch = float(sys.argv[5])
+    yaw = 0
+    if len(sys.argv) > 6:
+        yaw = float(sys.argv[6])
+
+    rospy.init_node("ray_query_3d", anonymous=True)
+
+    ray_query_srv = rospy.ServiceProxy("/move_base/local_costmap/ray_query_3d",
+                                      costmap_3d.srv.RayQuery3DService)
+    req = costmap_3d.srv.RayQuery3DServiceRequest()
+    req.header.frame_id = "base_footprint"
+    req.header.stamp = rospy.Time.now()
+    req.width = .1
+    req.height = .2
+    req.transform_wait_time_limit = 0.1
+    pose = geometry_msgs.msg.Pose()
+    pose.position.x = x
+    pose.position.y = y
+    pose.position.z = z
+    for yaw_delta in range(-180, 180, 5):
+        for pitch_delta in range(-50, 50, 5):
+            pose.orientation = geometry_msgs.msg.Quaternion(
+                    *tf.transformations.quaternion_from_euler(
+                        roll,
+                        pitch + pitch_delta * math.pi / 180.00,
+                        yaw + yaw_delta * math.pi / 180.0))
+            req.ray_poses.append(copy.deepcopy(pose))
+    rospy.loginfo("Request: " + str(req))
+    res = ray_query_srv(req)
+    rospy.loginfo("Result: " + str(res))

--- a/costmap_3d/src/costmap_3d_ros.cpp
+++ b/costmap_3d/src/costmap_3d_ros.cpp
@@ -46,6 +46,7 @@
 #include <costmap_3d/layered_costmap_3d.h>
 #include <tf/transform_datatypes.h>
 #include <visualization_msgs/Marker.h>
+#include <visualization_msgs/MarkerArray.h>
 
 namespace costmap_3d
 {
@@ -62,6 +63,11 @@ Costmap3DROS::Costmap3DROS(std::string name, tf::TransformListener& tf)
         private_nh_,
         "get_plan_cost_3d",
         std::bind(&Costmap3DROS::getPlanCost3DActionCallback, this, std::placeholders::_1),
+        false),
+    ray_query_action_srv_(
+        private_nh_,
+        "ray_query_3d",
+        std::bind(&Costmap3DROS::rayQuery3DActionCallback, this, std::placeholders::_1),
         false)
 {
   {
@@ -100,6 +106,7 @@ Costmap3DROS::Costmap3DROS(std::string name, tf::TransformListener& tf)
       ROS_WARN_STREAM("3D costmap \"" << name << "\" has no 3D plugin layers, will be 2D only");
     }
     footprint_pub_ = private_nh_.advertise<visualization_msgs::Marker>("footprint_3d", 1, true);
+    ray_query_3d_visualization_pub_ = private_nh_.advertise<visualization_msgs::MarkerArray>("ray_query_3d_visualization", 1, true);
     initialized_ = true;
   }
 
@@ -116,6 +123,12 @@ Costmap3DROS::Costmap3DROS(std::string name, tf::TransformListener& tf)
       "get_plan_cost_3d",
       &Costmap3DROS::getPlanCost3DServiceCallback,
       this);
+
+  ray_query_action_srv_.start();
+  ray_query_srv_ = private_nh_.advertiseService(
+      "ray_query_3d",
+      &Costmap3DROS::rayQuery3DServiceCallback,
+      this);
 }
 
 Costmap3DROS::~Costmap3DROS()
@@ -131,6 +144,8 @@ void Costmap3DROS::reconfigureCB(Costmap3DConfig &config, uint32_t level)
   footprint_3d_padding_ = config.footprint_3d_padding;
 
   publishFootprint();
+
+  visualize_ray_query_miss_ = config.visualize_ray_query_miss;
 }
 
 void Costmap3DROS::updateMap()
@@ -361,20 +376,39 @@ void Costmap3DROS::publishFootprint()
   footprint_pub_.publish(marker);
 }
 
-std::shared_ptr<Costmap3DQuery> Costmap3DROS::getQuery(const std::string& footprint_mesh_resource, double padding)
+std::shared_ptr<Costmap3DQuery> Costmap3DROS::getQuery(
+    const std::string& footprint_mesh_resource,
+    double padding,
+    Costmap3DQuery::QueryRegionScale query_region_scale,
+    unsigned int pose_bins_per_meter,
+    unsigned int pose_bins_per_radian,
+    unsigned int pose_milli_bins_per_meter,
+    unsigned int pose_milli_bins_per_radian,
+    unsigned int pose_micro_bins_per_meter,
+    unsigned int pose_micro_bins_per_radian)
 {
   const std::string& query_mesh(getFootprintMeshResource(footprint_mesh_resource));
   padding = getFootprintPadding(padding);
-  auto query_pair = std::make_pair(query_mesh, padding);
+  auto query_key = std::make_tuple(query_mesh, padding, query_region_scale);
   upgrade_lock upgrade_lock(query_map_mutex_);
-  auto query_it = query_map_.find(query_pair);
+  auto query_it = query_map_.find(query_key);
   if (query_it == query_map_.end())
   {
     // Query object does not exist, create it and add it to the map
     std::shared_ptr<Costmap3DQuery> query;
-    query.reset(new Costmap3DQuery(&layered_costmap_3d_, query_mesh, padding));
+    query.reset(new Costmap3DQuery(
+            &layered_costmap_3d_,
+            query_mesh,
+            padding,
+            query_region_scale,
+            pose_bins_per_meter,
+            pose_bins_per_radian,
+            pose_milli_bins_per_meter,
+            pose_milli_bins_per_radian,
+            pose_micro_bins_per_meter,
+            pose_micro_bins_per_radian));
     upgrade_to_unique_lock write_lock(upgrade_lock);
-    query_it = query_map_.insert(std::make_pair(query_pair, query)).first;
+    query_it = query_map_.insert(std::make_pair(query_key, query)).first;
   }
   return query_it->second;
 }
@@ -587,15 +621,15 @@ std::shared_ptr<Costmap3DQuery> Costmap3DROS::getBufferedQueryForService(
 {
   const std::string& query_mesh(getFootprintMeshResource(footprint_mesh_resource));
   padding = getFootprintPadding(padding);
-  auto query_pair = std::make_pair(query_mesh, padding);
+  auto query_key = std::make_tuple(query_mesh, padding, Costmap3DQuery::QueryRegionScale::Zero());
   // No need to lock the service_buffered_query_map_ because we must be holding
   // the service_mutex_
-  auto query_it = service_buffered_query_map_.find(query_pair);
+  auto query_it = service_buffered_query_map_.find(query_key);
   if (query_it == service_buffered_query_map_.end())
   {
     // Query object does not exist, create it and add it to the map
     std::shared_ptr<Costmap3DQuery> query = getBufferedQuery(query_mesh, padding);
-    query_it = service_buffered_query_map_.insert(std::make_pair(query_pair, query)).first;
+    query_it = service_buffered_query_map_.insert(std::make_pair(query_key, query)).first;
   }
   else
   {
@@ -604,5 +638,199 @@ std::shared_ptr<Costmap3DQuery> Costmap3DROS::getBufferedQueryForService(
   }
   return query_it->second;
 }
+
+void Costmap3DROS::rayQuery3DActionCallback(
+    const actionlib::SimpleActionServer<RayQuery3DAction>::GoalConstPtr& goal)
+{
+  RayQuery3DResult result;
+  if (processRayQuery3D(*goal, result))
+  {
+    ray_query_action_srv_.setSucceeded(result);
+  }
+  else
+  {
+    ray_query_action_srv_.setAborted();
+  }
+}
+
+bool Costmap3DROS::rayQuery3DServiceCallback(
+    RayQuery3DService::Request& request,
+    RayQuery3DService::Response& response)
+{
+  return processRayQuery3D(request, response);
+}
+
+static void setTriangleListRectangle(const geometry_msgs::Point& upper_left,
+                                     const geometry_msgs::Point& upper_right,
+                                     const geometry_msgs::Point& lower_right,
+                                     const geometry_msgs::Point& lower_left,
+                                     visualization_msgs::Marker* marker)
+{
+  marker->points.push_back(upper_left);
+  marker->points.push_back(upper_right);
+  marker->points.push_back(lower_right);
+  marker->points.push_back(upper_left);
+  marker->points.push_back(lower_right);
+  marker->points.push_back(lower_left);
+}
+
+static void setRectangularPrismMarker(double width, double height, double distance, visualization_msgs::Marker* marker)
+{
+  // Cap distance to 1000 km to avoid overflow around max double.
+  distance = std::min(distance, 1000000.0);
+
+  marker->points.clear();
+
+  geometry_msgs::Point base_upper_left;
+  base_upper_left.x = 0.0;
+  base_upper_left.y = -width / 2.0;
+  base_upper_left.z = height / 2.0;
+  geometry_msgs::Point base_upper_right;
+  base_upper_right.x = 0.0;
+  base_upper_right.y = width / 2.0;
+  base_upper_right.z = height / 2.0;
+  geometry_msgs::Point base_lower_right;
+  base_lower_right.x = 0.0;
+  base_lower_right.y = width / 2.0;
+  base_lower_right.z = -height / 2.0;
+  geometry_msgs::Point base_lower_left;
+  base_lower_left.x = 0.0;
+  base_lower_left.y = -width / 2.0;
+  base_lower_left.z = -height / 2.0;
+  geometry_msgs::Point top_upper_left;
+  top_upper_left.x = distance;
+  top_upper_left.y = -width / 2.0;
+  top_upper_left.z = height / 2.0;
+  geometry_msgs::Point top_upper_right;
+  top_upper_right.x = distance;
+  top_upper_right.y = width / 2.0;
+  top_upper_right.z = height / 2.0;
+  geometry_msgs::Point top_lower_right;
+  top_lower_right.x = distance;
+  top_lower_right.y = width / 2.0;
+  top_lower_right.z = -height / 2.0;
+  geometry_msgs::Point top_lower_left;
+  top_lower_left.x = distance;
+  top_lower_left.y = -width / 2.0;
+  top_lower_left.z = -height / 2.0;
+
+  setTriangleListRectangle(base_upper_left,
+                           base_upper_right,
+                           base_lower_right,
+                           base_lower_left,
+                           marker);
+  setTriangleListRectangle(base_upper_left,
+                           top_upper_left,
+                           top_upper_right,
+                           base_upper_right,
+                           marker);
+  setTriangleListRectangle(base_upper_right,
+                           top_upper_right,
+                           top_lower_right,
+                           base_lower_right,
+                           marker);
+  setTriangleListRectangle(base_lower_right,
+                           top_lower_right,
+                           top_lower_left,
+                           base_lower_left,
+                           marker);
+  setTriangleListRectangle(base_lower_left,
+                           top_lower_left,
+                           top_upper_left,
+                           base_upper_left,
+                           marker);
+  setTriangleListRectangle(top_upper_right,
+                           top_upper_left,
+                           top_lower_left,
+                           top_lower_right,
+                           marker);
+}
+
+template <typename RequestType, typename ResponseType>
+bool Costmap3DROS::processRayQuery3D(RequestType& request, ResponseType& response)
+{
+  float timeout_seconds = (request.transform_wait_time_limit > 0) ?
+    request.transform_wait_time_limit : 0.1;
+  if (!tf_.waitForTransform(layered_costmap_3d_.getGlobalFrameID(),
+      request.header.frame_id, request.header.stamp,
+      ros::Duration(timeout_seconds)))
+  {
+    return false;
+  }
+
+  // Be sure the costmap is locked while querying
+  std::unique_lock <LayeredCostmap3D> lock(layered_costmap_3d_);
+  std::shared_ptr<Costmap3DQuery> query;
+
+#if (COSTMAP_3D_ROS_AUTO_PROFILE_QUERY) > 0
+  ROS_INFO("Starting rayQuery3DServiceCallback");
+  ros::Time start_time = ros::Time::now();
+  kill(getpid(), 12);
+#endif
+
+  Costmap3DQuery::QueryRegionScale scale;
+  scale(0) = 0.0;
+  scale(1) = request.width;
+  scale(2) = request.height;
+
+  // Always use a point for the "mesh"
+  query = getQuery("package://costmap_3d/meshes/point.stl", 0.0, scale);
+
+  Costmap3DQuery::DistanceOptions dopts;
+  dopts.query_region = Costmap3DQuery::RECTANGULAR_PRISM;
+  dopts.relative_error = 0.0;
+
+  visualization_msgs::MarkerArray marker_array;
+  std::string ns = private_nh_.getNamespace() + "/ray_query_3d_visualization";
+  unsigned int marker_id = 1;
+  visualization_msgs::Marker marker;
+
+  marker.header = request.header;
+  marker.ns = private_nh_.getNamespace();
+  marker.type = visualization_msgs::Marker::TRIANGLE_LIST;
+  marker.action = visualization_msgs::Marker::DELETEALL;
+  marker.scale.x = 1.0;
+  marker.scale.y = 1.0;
+  marker.scale.z = 1.0;
+  marker.color.a = 0.25;
+  marker.color.r = 1.0;
+  marker.color.g = 1.0;
+  marker.color.b = 0.0;
+
+  response.distances.reserve(request.ray_poses.size());
+  marker_array.markers.reserve(request.ray_poses.size()+1);
+  marker_array.markers.push_back(marker);
+  marker.action = visualization_msgs::Marker::ADD;
+  for (int i = 0; i < request.ray_poses.size(); ++i)
+  {
+    geometry_msgs::PoseStamped ray_pose, query_pose;
+
+    ray_pose.header = request.header;
+    ray_pose.pose = request.ray_poses[i];
+    tf_.transformPose(layered_costmap_3d_.getGlobalFrameID(), ray_pose, query_pose);
+
+    double pose_distance = query->footprintDistance(query_pose.pose, dopts);
+
+    response.distances.push_back(pose_distance);
+
+    if (visualize_ray_query_miss_ || pose_distance < std::numeric_limits<double>::max())
+    {
+      marker.id = marker_id++;
+      marker.pose = ray_pose.pose;
+      setRectangularPrismMarker(request.width, request.height, pose_distance, &marker);
+      marker_array.markers.push_back(marker);
+    }
+  }
+  ray_query_3d_visualization_pub_.publish(marker_array);
+
+#if (COSTMAP_3D_ROS_AUTO_PROFILE_QUERY) > 0
+  kill(getpid(), 12);
+  ROS_INFO_STREAM("Finished getting " << request.poses.size() << " poses in " <<
+                  (ros::Time::now() - start_time).toSec() << " seconds.");
+#endif
+
+  return true;
+}
+
 
 }  // namespace costmap_3d

--- a/costmap_3d/srv/GetPlanCost3DService.srv
+++ b/costmap_3d/srv/GetPlanCost3DService.srv
@@ -35,6 +35,11 @@ uint8 COST_QUERY_REGION_ALL=0
 uint8 COST_QUERY_REGION_LEFT=1
 # Query the map only to the right of each query pose.
 uint8 COST_QUERY_REGION_RIGHT=2
+# Query a 1m by 1m rectangular prism starting at the origin of each pose.
+# To alter the size of the prism in the frame of the pose, scale the
+# pose's quaternion appropriately to scale the prism when it is transformed.
+# To scale the width differently from the height, use the ray query interface.
+uint8 COST_QUERY_REGION_RECTANGULAR_PRISM=3
 # Set to one of the above COST_QUERY_REGION_* to control query region per pose.
 # If the region is missing for a given pose, COST_QUERY_REGION_ALL is assumed.
 uint8[] cost_query_regions

--- a/costmap_3d/srv/RayQuery3DService.srv
+++ b/costmap_3d/srv/RayQuery3DService.srv
@@ -1,0 +1,27 @@
+# Get the distances to nearest occupied voxel on rectangular prismatic rays.
+# For each ray pose, the rectangular prism is assumed to be originated at (0,
+# 0, 0) and oriented along the x-axis with the width on the y-axis and the
+# height on the z-axis.
+Header header
+
+# Rays to query. The prism is transformed using each pose into
+# header.frame_id at time header.stamp, and then into the fixed frame of the
+# costmap to perform the query. Essentially, each ray pose defines a temporary
+# frame of reference for the rectangular prism for each query ray.
+geometry_msgs/Pose[] ray_poses
+
+# Width of rectangular prism query region in meters.
+float64 width
+
+# Height of rectangular prism query region in meters.
+float64 height
+
+# The maximum amount of time (seconds) to wait for a transform to become
+# available to transform a pose. (default=0.1, any values <= 0 will be
+# converted to the default.)
+float32 transform_wait_time_limit
+---
+# The distance from the origin of each ray pose to the nearest costmap voxel
+# inside the region of interest defined by the rectangular prism.
+# If no voxel was found, the distance will be equal to DBL_MAX.
+float64[] distances


### PR DESCRIPTION
Add ability to query a rectangular prism from a pose to Costmap3DQuery. Add a new ray query action server and service so ROS nodes external to navigation can query rays in the 3D costmap.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/navigation/36)
<!-- Reviewable:end -->
