### PR TITLE
Costmap 3d add "if unknown" layer combination method

### DIFF
--- a/costmap_3d/cfg/GenericPlugin.cfg
+++ b/costmap_3d/cfg/GenericPlugin.cfg
@@ -7,6 +7,7 @@ gen.add("enabled", bool_t, 0, "Whether to apply this plugin or not", True)
 
 combo_enum = gen.enum([ gen.const("Overwrite", int_t,  0, "Overwrite values"),
                         gen.const("Maximum",   int_t,  1, "Take the maximum of the values"),
+                        gen.const("IfUnknown", int_t,  2, "Update if the voxel is unknown"),
                         gen.const("Nothing",   int_t, 99, "Do nothing")
                       ],
                       "Method for combining layers enum")

--- a/costmap_3d/include/costmap_3d/costmap_3d.h
+++ b/costmap_3d/include/costmap_3d/costmap_3d.h
@@ -44,13 +44,6 @@
 namespace costmap_3d
 {
 
-enum CombinationMethod
-{
-  OVERWRITE = 0,
-  MAXIMUM = 1,
-  NOTHING = 99,
-};
-
 /* OccupancyOcTree Log odds values for various costmap states. */
 typedef float Cost;
 // Sentinel. Don't choose NAN as it can't be pruned in octomap

--- a/costmap_3d/src/costmap_layer_3d.cpp
+++ b/costmap_3d/src/costmap_layer_3d.cpp
@@ -86,6 +86,18 @@ void CostmapLayer3D::updateCosts(const Costmap3D& bounds_map, Costmap3D* master_
       case GenericPlugin_Maximum:
         master_map->setTreeValues(static_cast<const Costmap3D*>(costmap_.get()), &bounds_map, true, false);
         break;
+      case GenericPlugin_IfUnknown:
+        master_map->setTreeValues(static_cast<const Costmap3D*>(costmap_.get()), &bounds_map, false, false,
+                                  [](const Costmap3D::NodeType* layer_node, Costmap3D::NodeType* master_node, bool node_just_created, const octomap::OcTreeKey&, unsigned int)
+                                  {
+                                    // Only copy data for newly created nodes.
+                                    // A new node indicates that the node did not exist in the master map.
+                                    if (node_just_created)
+                                    {
+                                      master_node->copyData(*layer_node);
+                                    }
+                                  });
+        break;
       default:
       case GenericPlugin_Nothing:
         // In case this was a mistake, give info once that we are using NOTHING


### PR DESCRIPTION
Add a new combination method "if unknown". This allows a lower layer to only set its contents when there are no contents yet. This is useful for static maps, for instance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/navigation/38)
<!-- Reviewable:end -->
