### PR TITLE
costmap-3d: index tls cache by query obstacle type

### DIFF
--- a/costmap_3d/include/costmap_3d/costmap_3d_query.h
+++ b/costmap_3d/include/costmap_3d/costmap_3d_query.h
@@ -665,7 +665,7 @@ private:
   static thread_local unsigned int tls_last_layered_costmap_update_number_;
   static thread_local Costmap3DQuery* tls_last_instance_;
   /// Indexed by QueryRegion
-  static thread_local DistanceCacheEntry* tls_last_cache_entries_[MAX];
+  static thread_local DistanceCacheEntry* tls_last_cache_entries_[MAX][OBSTACLES_MAX];
   /**
    * The distance cache allows us to find a very good distance guess quickly.
    * The cache memorizes to a hash table for a pose rounded to the number of


### PR DESCRIPTION
The thread local storage distance cache was not being indexed by the
query obstacle type (lethal vs. nonlethal). This is a nasty buy as
the query may incorrectly limit the distance based on an octomap box
that will not be considered. The fix is to index the tls cache by the
obstacle type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/navigation/39)
<!-- Reviewable:end -->
