### PR TITLE
costmap_3d: fix resub race logic in octomap plugin

### DIFF
--- a/costmap_3d/plugins/octomap_server_layer_3d.cpp
+++ b/costmap_3d/plugins/octomap_server_layer_3d.cpp
@@ -302,21 +302,23 @@ void OctomapServerLayer3D::mapUpdateCallback(const octomap_msgs::OctomapUpdateCo
     // from the octomap_update seq.
     // Ignore the first normal published update until the first full map
     // is received.
-    if (num_map_updates_ == 1 &&
-        map_update_msg->octomap_bounds.header.seq == map_update_msg->octomap_update.header.seq)
+    if (map_update_msg->octomap_bounds.header.seq == map_update_msg->octomap_update.header.seq)
     {
-      // Ignore the first normal update until the first full map is received.
-      // There is a race where this may happen, and we must simply ignore the
-      // first.
-      return;
-    }
-    else if(num_map_updates_ > 1)
-    {
-      // Huh. We never got the first full map, this means we lost that
-      // message. We have no choice but to re-subscribe.
-      ROS_WARN("Lost first full map update message, resubscribing.");
-      scheduleResubscribeUpdates();
-      return;
+      if (num_map_updates_ <= 1)
+      {
+        // Ignore the first normal update until the first full map is received.
+        // There is a race where this may happen, and we must simply ignore the
+        // first.
+        return;
+      }
+      else
+      {
+        // Huh. We never got the first full map, this means we lost that
+        // message. We have no choice but to re-subscribe.
+        ROS_WARN("Lost first full map update message, resubscribing.");
+        scheduleResubscribeUpdates();
+        return;
+      }
     }
     first_full_map_update_received_ = true;
   }


### PR DESCRIPTION
The logic to fix the resub race in the octomap plugin was incorrect.
The sequence number was not retested, resulting in always
resubscribing when the race between the first full update and the
first update message was lost.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/navigation/42)
<!-- Reviewable:end -->
