### PR TITLE
costmap_3d: only attempt one resubscribe at a time

### DIFF
--- a/costmap_3d/include/costmap_3d/octomap_server_layer_3d.h
+++ b/costmap_3d/include/costmap_3d/octomap_server_layer_3d.h
@@ -106,6 +106,7 @@ protected:
   bool using_updates_;
   bool active_;
   bool first_full_map_update_received_;
+  bool resub_pending_;
   size_t num_map_updates_;
   uint32_t last_seq_;
   ros::Duration data_valid_duration_;


### PR DESCRIPTION
Do not allow multiple resub timers to be queued in the node handle.
Instead, track when a resub is pending and wait for it to complete
before attempting again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/navigation/43)
<!-- Reviewable:end -->
