### PR TITLE
costmap_3d: add exact signed distance query mode

### DIFF
--- a/costmap_3d/include/costmap_3d/costmap_3d_query.h
+++ b/costmap_3d/include/costmap_3d/costmap_3d_query.h
@@ -195,7 +195,8 @@ public:
   virtual double footprintSignedDistance(const geometry_msgs::Pose& pose,
                                          QueryRegion query_region = ALL,
                                          bool reuse_past_result = false,
-                                         double relative_error = 0.05);
+                                         double relative_error = 0.05,
+                                         bool exact_signed_distance = false);
 
   using FCLFloat = double;
   struct DistanceOptions
@@ -206,6 +207,11 @@ public:
     QueryObstacles query_obstacles = LETHAL_ONLY;
     //! Whether to find the signed distance on collision
     bool signed_distance = false;
+    /** Whether to find the exact signed distance, or relaxed signed distance
+     * (where derivatives are consistent, collisions are correct, but the exact
+     * penetration depth is not returned). Only effective if signed_distance is true
+     */
+    bool exact_signed_distance = false;
     //! Whether to reuse the previous box/mesh triangle result directly
     bool reuse_past_result = false;
     //! Acceptable relative error limit (improves runtime)

--- a/costmap_3d/src/costmap_3d_query.cpp
+++ b/costmap_3d/src/costmap_3d_query.cpp
@@ -853,7 +853,12 @@ double Costmap3DQuery::calculateDistance(const geometry_msgs::Pose& pose,
     octree_solver.setUncertainOnly(true);
   }
 
-  if (result.min_distance > 0.0)
+  if (opts.exact_signed_distance)
+  {
+    octree_solver.setExactSignedDistance(true);
+  }
+
+  if (result.min_distance > 0.0 || opts.exact_signed_distance)
   {
     fcl::OcTree<FCLFloat> fcl_octree(octree_to_query);
     // Always setup the correct occupancy limits
@@ -960,13 +965,15 @@ double Costmap3DQuery::footprintDistance(const geometry_msgs::Pose& pose,
 double Costmap3DQuery::footprintSignedDistance(const geometry_msgs::Pose& pose,
                                                Costmap3DQuery::QueryRegion query_region,
                                                bool reuse_past_result,
-                                               double relative_error)
+                                               double relative_error,
+                                               bool exact_signed_distance)
 {
   DistanceOptions opts;
   opts.query_region = query_region;
   opts.reuse_past_result = reuse_past_result;
   opts.relative_error = relative_error;
   opts.signed_distance = true;
+  opts.exact_signed_distance = exact_signed_distance;
   return calculateDistance(pose, opts);
 }
 

--- a/costmap_3d/src/costmap_3d_ros.cpp
+++ b/costmap_3d/src/costmap_3d_ros.cpp
@@ -488,7 +488,8 @@ void Costmap3DROS::processPlanCost3D(RequestType& request, ResponseType& respons
   }
 
   if (request.cost_query_mode == costmap_3d_msgs::GetPlanCost3DService::Request::COST_QUERY_MODE_DISTANCE ||
-      request.cost_query_mode == costmap_3d_msgs::GetPlanCost3DService::Request::COST_QUERY_MODE_SIGNED_DISTANCE)
+      request.cost_query_mode == costmap_3d_msgs::GetPlanCost3DService::Request::COST_QUERY_MODE_SIGNED_DISTANCE ||
+      request.cost_query_mode == costmap_3d_msgs::GetPlanCost3DService::Request::COST_QUERY_MODE_EXACT_SIGNED_DISTANCE)
   {
     response.cost = std::numeric_limits<double>::max();
   }
@@ -542,6 +543,12 @@ void Costmap3DROS::processPlanCost3D(RequestType& request, ResponseType& respons
         {
           dopts.signed_distance = true;
         }
+        if (request.cost_query_mode == costmap_3d_msgs::GetPlanCost3DService::Request::COST_QUERY_MODE_EXACT_SIGNED_DISTANCE)
+        {
+          dopts.signed_distance = true;
+          dopts.exact_signed_distance = true;
+          dopts.relative_error = 0.0;
+        }
         pose_cost = query->footprintDistance(pose.pose, dopts);
       }
     }
@@ -559,7 +566,8 @@ void Costmap3DROS::processPlanCost3D(RequestType& request, ResponseType& respons
       collision = true;
     }
     if (request.cost_query_mode == costmap_3d_msgs::GetPlanCost3DService::Request::COST_QUERY_MODE_DISTANCE ||
-        request.cost_query_mode == costmap_3d_msgs::GetPlanCost3DService::Request::COST_QUERY_MODE_SIGNED_DISTANCE)
+        request.cost_query_mode == costmap_3d_msgs::GetPlanCost3DService::Request::COST_QUERY_MODE_SIGNED_DISTANCE ||
+        request.cost_query_mode == costmap_3d_msgs::GetPlanCost3DService::Request::COST_QUERY_MODE_EXACT_SIGNED_DISTANCE)
     {
       // in distance mode, the cost is the minimum distance across all poses
       response.cost = std::min(response.cost, pose_cost);

--- a/costmap_3d_msgs/action/GetPlanCost3D.action
+++ b/costmap_3d_msgs/action/GetPlanCost3D.action
@@ -25,6 +25,11 @@ uint8 COST_QUERY_MODE_DISTANCE=2
 # in position/orientation will generate a derivative pointing away from
 # one of the penetration points (not necessarily the deepest).
 uint8 COST_QUERY_MODE_SIGNED_DISTANCE=3
+# Do not find actual costs, find exact signed distances instead.
+# Exact distances are more expensive to calculate when many voxels are inside
+# the footprint mesh. Only use exact signed distance when exact penetration
+# depth is necessary.
+uint8 COST_QUERY_MODE_EXACT_SIGNED_DISTANCE=4
 # Set to one of the above COST_QUERY_MODE_* to control query mode.
 # The default is COST_QUERY_MODE_COST.
 uint8 cost_query_mode

--- a/costmap_3d_msgs/srv/GetPlanCost3DService.srv
+++ b/costmap_3d_msgs/srv/GetPlanCost3DService.srv
@@ -25,6 +25,11 @@ uint8 COST_QUERY_MODE_DISTANCE=2
 # in position/orientation will generate a derivative pointing away from
 # one of the penetration points (not necessarily the deepest).
 uint8 COST_QUERY_MODE_SIGNED_DISTANCE=3
+# Do not find actual costs, find exact signed distances instead.
+# Exact distances are more expensive to calculate when many voxels are inside
+# the footprint mesh. Only use exact signed distance when exact penetration
+# depth is necessary.
+uint8 COST_QUERY_MODE_EXACT_SIGNED_DISTANCE=4
 # Set to one of the above COST_QUERY_MODE_* to control query mode.
 # The default is COST_QUERY_MODE_COST.
 uint8 cost_query_mode


### PR DESCRIPTION
Add a new exact signed distance mode to queries. This mode will find the exact signed distance by not stopping the distance query when a collision is found, but exhausting all interior collisions to find the deepest. The normal (relaxed) signed distance mode stops as soon as a collision is found, but still allows the caller to keep derivates consistent by use of the reuse last result option. Some users of costmap queries (such as recovery planners) want to know the *exact* penetration depth for any particular pose of the mesh, and can do so now with this new exact signed distance query mode.

Note: to get exact penetration depth requires also setting the relative error to zero. If only penetration depth is needed, the min_distance could be set via the distance options to just above zero to speed up non-colliding queries. Also, exact signed distance does not imply exact distance for non-collisions which are still short circuited by the milli and micro caches. Those can be disabled by creating a query object with the milli and micro cache distance thresholds set to the maximum value (preventing them from being directly used to calculate distance on a hit). Such precise distances in non-collision cases should not be necessary for normal use cases.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BadgerTechnologies/navigation/46)
<!-- Reviewable:end -->
