### PR TITLE
Costmap 3d query fixes

### DIFF
--- a/costmap_3d/include/costmap_3d/costmap_3d_query.h
+++ b/costmap_3d/include/costmap_3d/costmap_3d_query.h
@@ -792,6 +792,8 @@ private:
   // Statistics gathered between clearing cycles
   void printStatistics();
   void clearStatistics();
+  // Only track statistics if the named logger is enabled.
+  bool track_statistics_ = false;
   // Use std::atomic so we can increment with only the read lock held.
   // The write lock will be held when resetting these so they all reset
   // atomically

--- a/costmap_3d/include/costmap_3d/costmap_3d_query.h
+++ b/costmap_3d/include/costmap_3d/costmap_3d_query.h
@@ -280,6 +280,7 @@ protected:
   const LayeredCostmap3D* layered_costmap_3d_;
 
   using upgrade_mutex = boost::upgrade_mutex;
+  using shared_lock = boost::shared_lock<upgrade_mutex>;
   using upgrade_lock = boost::upgrade_lock<upgrade_mutex>;
   using upgrade_to_unique_lock = boost::upgrade_to_unique_lock<upgrade_mutex>;
   using unique_lock = boost::unique_lock<upgrade_mutex>;
@@ -294,6 +295,25 @@ protected:
    */
   virtual void checkCostmap(upgrade_lock& upgrade_lock,
                             std::shared_ptr<const octomap::OcTree> new_octree = nullptr);
+
+  /** @brief See if checkCostmap may be needed.
+   * Note: must be called holding at least a shared lock on the upgrade_mutex_
+   * Returns true if checkCostmap should be called. The whole point of this
+   * method is to keep from having to obtain an upgrade lock unless the costmap
+   * may actually have changed, which can be determined while holding a shared
+   * lock.
+   */
+  virtual bool needCheckCostmap(std::shared_ptr<const octomap::OcTree> new_octree = nullptr);
+
+  /** @brief Check and invalidate TLS if necessary.
+   *
+   * Because checkCostmap will only invalidate instance-wide state, TLS state
+   * must be checked on every query prior to using the TLS cache to see if it
+   * is still valid. This is because the thread checkCostmap ends up
+   * invalidating instance-wide state runs on can not see the TLS of other
+   * threads (by design) Checking TLS state is lockless so this is cheap.
+   */
+  virtual void checkTLS();
 
   /** @brief Update the mesh to use for queries. */
   virtual void updateMeshResource(const std::string& mesh_resource, double padding = 0.0);

--- a/costmap_3d/include/costmap_3d/costmap_3d_query.h
+++ b/costmap_3d/include/costmap_3d/costmap_3d_query.h
@@ -281,8 +281,15 @@ public:
 
   /** @brief change the costmap associated with this query.
    *
-   * This is useful for a buffered query to save the robot mesh LUT, which would be
-   * re-created if a new query is allocated.
+   * This is useful for a buffered query to save the robot mesh LUT, which
+   * would be re-created if a new query is allocated.
+   *
+   * Note: for a buffered query it is necessary to ensure that this method is
+   * only called when there are no outstanding queries. Buffered queries are
+   * optimized to not hold the upgrade_mutex_ during the query, as the only
+   * time a buffered query can change is when either updateCostmap or
+   * updateMeshResource is called. This is not true for an associated query, as
+   * the costmap may change between queries with no update method being called.
    */
   void updateCostmap(const Costmap3DConstPtr& costmap_3d);
 
@@ -345,7 +352,15 @@ protected:
    */
   virtual void checkTLS();
 
-  /** @brief Update the mesh to use for queries. */
+  /** @brief Update the mesh to use for queries.
+   *
+   * Note: for a buffered query it is necessary to ensure that this method is
+   * only called when there are no outstanding queries. Buffered queries are
+   * optimized to not hold the upgrade_mutex_ during the query, as the only
+   * time a buffered query can change is when either updateCostmap or
+   * updateMeshResource is called. This is not true for an associated query, as
+   * the costmap may change between queries with no update method being called.
+   */
   virtual void updateMeshResource(const std::string& mesh_resource, double padding = 0.0);
 
   /** @brief core of distance calculations */

--- a/costmap_3d/include/costmap_3d/costmap_3d_query.h
+++ b/costmap_3d/include/costmap_3d/costmap_3d_query.h
@@ -539,6 +539,15 @@ private:
       result->tf1 = octomap_box_tf;
       result->b2 = mesh_triangle_id;
     }
+    void clear()
+    {
+      octomap_box.reset();
+      mesh_triangle.reset();
+    }
+    explicit operator bool() const
+    {
+      return octomap_box && mesh_triangle;
+    }
     bool getCostmapIndexAndDepth(const octomap::OcTreeSpace& octree_space, Costmap3DIndex* index, unsigned int* depth)
     {
       if (octomap_box)
@@ -671,7 +680,7 @@ private:
   static thread_local unsigned int tls_last_layered_costmap_update_number_;
   static thread_local Costmap3DQuery* tls_last_instance_;
   /// Indexed by QueryRegion
-  static thread_local DistanceCacheEntry* tls_last_cache_entries_[MAX][OBSTACLES_MAX];
+  static thread_local DistanceCacheEntry tls_last_cache_entries_[MAX][OBSTACLES_MAX];
   /**
    * The distance cache allows us to find a very good distance guess quickly.
    * The cache memorizes to a hash table for a pose rounded to the number of

--- a/costmap_3d/src/costmap_3d_query.cpp
+++ b/costmap_3d/src/costmap_3d_query.cpp
@@ -406,10 +406,8 @@ void Costmap3DQuery::checkCostmap(Costmap3DQuery::upgrade_lock& upgrade_lock,
           "milli-distance cache removed " << start_size - milli_distance_cache_.size() << " entries");
     }
 
-    // Drop the micro cache. It is not worth iterating over the (relatively
-    // large) micro cache.  New entries in the costmap make the upper bound
-    // fairly worthless and we can not use the fast path which is the micro
-    // cache's strong point.
+    // Drop the micro cache as even if we removed invalid entries we can not
+    // use the fast path which is the micro cache's strong point.
     printDistanceCacheDebug(micro_distance_cache_, "micro-distance cache: ");
     micro_distance_cache_.clear();
     // We must drop the exact cache after the costmap has changed

--- a/costmap_3d/src/costmap_3d_query.cpp
+++ b/costmap_3d/src/costmap_3d_query.cpp
@@ -419,6 +419,7 @@ void Costmap3DQuery::addPCLPolygonMeshToRobotModel(
 
 void Costmap3DQuery::updateMeshResource(const std::string& mesh_resource, double padding)
 {
+  unique_lock write_lock(upgrade_mutex_);
   std::string filename = getFileNameFromPackageURL(mesh_resource);
   if (filename.size() == 0)
   {

--- a/costmap_3d/src/costmap_3d_query.cpp
+++ b/costmap_3d/src/costmap_3d_query.cpp
@@ -36,6 +36,7 @@
  *********************************************************************/
 #include <costmap_3d/costmap_3d_query.h>
 #include <chrono>
+#include <sstream>
 #include <fcl/geometry/octree/octree.h>
 #include <fcl/narrowphase/collision.h>
 #include <fcl/narrowphase/distance_result.h>
@@ -455,9 +456,8 @@ void Costmap3DQuery::printStatistics()
       slow_micro_hits_since_clear_us_ +
       reuse_results_since_clear_us_ +
       exact_hits_since_clear_us_;
-  ROS_DEBUG_STREAM_NAMED(
-      "query_statistics",
-      "Costmap3DQuery statistics:"
+  std::ostringstream ss;
+  ss << "Costmap3DQuery statistics:"
       "\n\tqueries this cycle: " << queries_since_clear_ <<
       "\n\tcache misses: " << cache_misses <<
       "\n\tcache hits: " << hits_since_clear_ <<
@@ -486,7 +486,20 @@ void Costmap3DQuery::printStatistics()
       "\n\tmiss FCL BV distance calculations: " << miss_fcl_bv_distance_calculations_ <<
       "\n\tmiss FCL primative distance calculations: " << miss_fcl_primative_distance_calculations_ <<
       "\n\thit FCL BV distance calculations: " << hit_fcl_bv_distance_calculations_ <<
-      "\n\thit FCL primative distance calculations: " << hit_fcl_primative_distance_calculations_);
+      "\n\thit FCL primative distance calculations: " << hit_fcl_primative_distance_calculations_;
+  // Leverage the fact that the print arguments are only run if the log is
+  // enabled to make it simple to track if statistics tracking should be
+  // enabled. There is no need to pay for the atomic operations for statistics
+  // tracking if it is disabled.
+  bool should_track_statistics = false;
+  ROS_DEBUG_STREAM_NAMED(
+      "query_statistics",
+      // Weird construction here to get the side effect of setting
+      // should_track_statistics when the named debug is enabled. Also skips
+      // printing the first cycle as it will have invalid (zero) statistics
+      (((should_track_statistics = true) && track_statistics_) ? ss.str() :
+      "Costmap3DQuery: begin tracking statistics"));
+  track_statistics_ = should_track_statistics;
 }
 
 void Costmap3DQuery::addPCLPolygonToFCLTriangles(
@@ -709,9 +722,15 @@ double Costmap3DQuery::calculateDistance(const geometry_msgs::Pose& pose,
   // Make convenience aliases of some of the options
   const QueryRegion query_region = opts.query_region;
   const QueryObstacles query_obstacles = opts.query_obstacles;
+  // Let compiler optimize track_statistics by adding it to the stack.
+  const bool track_statistics = track_statistics_;
 
-  std::chrono::high_resolution_clock::time_point start_time = std::chrono::high_resolution_clock::now();
-  queries_since_clear_.fetch_add(1, std::memory_order_relaxed);
+  std::chrono::high_resolution_clock::time_point start_time;
+  if (track_statistics)
+  {
+    start_time = std::chrono::high_resolution_clock::now();
+    queries_since_clear_.fetch_add(1, std::memory_order_relaxed);
+  }
 
   // Use the passed in distance limit up to the "min" float (close to zero)
   // We do not want to use a zero or negative distance limit from the options
@@ -736,10 +755,13 @@ double Costmap3DQuery::calculateDistance(const geometry_msgs::Pose& pose,
       double distance = handleDistanceInteriorCollisions(
           tls_last_cache_entries_[query_region][query_obstacles],
           pose);
-      reuse_results_since_clear_.fetch_add(1, std::memory_order_relaxed);
-      reuse_results_since_clear_us_.fetch_add(
-          std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - start_time).count(),
-          std::memory_order_relaxed);
+      if (track_statistics)
+      {
+        reuse_results_since_clear_.fetch_add(1, std::memory_order_relaxed);
+        reuse_results_since_clear_us_.fetch_add(
+            std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - start_time).count(),
+            std::memory_order_relaxed);
+      }
       return distance;
     }
     else
@@ -816,7 +838,10 @@ double Costmap3DQuery::calculateDistance(const geometry_msgs::Pose& pose,
   // FCL does not correctly handle an empty octomap.
   if (octree_to_query->size() == 0 || !octree_to_query->isNodeOccupied(octree_to_query->getRoot()))
   {
-    empties_since_clear_.fetch_add(1, std::memory_order_relaxed);
+    if (track_statistics)
+    {
+      empties_since_clear_.fetch_add(1, std::memory_order_relaxed);
+    }
     return std::numeric_limits<double>::max();
   }
 
@@ -828,10 +853,13 @@ double Costmap3DQuery::calculateDistance(const geometry_msgs::Pose& pose,
     // Be sure to update the TLS last cache entry.
     // We do not need the write lock to update thread local storage.
     tls_last_cache_entries_[query_region][query_obstacles] = exact_cache_entry->second;
-    exact_hits_since_clear_.fetch_add(1, std::memory_order_relaxed);
-    exact_hits_since_clear_us_.fetch_add(
-        std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - start_time).count(),
-        std::memory_order_relaxed);
+    if (track_statistics)
+    {
+      exact_hits_since_clear_.fetch_add(1, std::memory_order_relaxed);
+      exact_hits_since_clear_us_.fetch_add(
+          std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - start_time).count(),
+          std::memory_order_relaxed);
+    }
     return distance;
   }
 
@@ -858,10 +886,13 @@ double Costmap3DQuery::calculateDistance(const geometry_msgs::Pose& pose,
       // Be sure to update the TLS last cache entry.
       // We do not need the write lock to update thread local storage.
       tls_last_cache_entries_[query_region][query_obstacles] = milli_cache_entry->second;
-      fast_milli_hits_since_clear_.fetch_add(1, std::memory_order_relaxed);
-      fast_milli_hits_since_clear_us_.fetch_add(
-          std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - start_time).count(),
-          std::memory_order_relaxed);
+      if (track_statistics)
+      {
+        fast_milli_hits_since_clear_.fetch_add(1, std::memory_order_relaxed);
+        fast_milli_hits_since_clear_us_.fetch_add(
+            std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - start_time).count(),
+            std::memory_order_relaxed);
+      }
       return distance;
     }
     else
@@ -891,10 +922,13 @@ double Costmap3DQuery::calculateDistance(const geometry_msgs::Pose& pose,
       // Be sure to update the TLS last cache entry.
       // We do not need the write lock to update thread local storage.
       tls_last_cache_entries_[query_region][query_obstacles] = micro_cache_entry->second;
-      fast_micro_hits_since_clear_.fetch_add(1, std::memory_order_relaxed);
-      fast_micro_hits_since_clear_us_.fetch_add(
-          std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - start_time).count(),
-          std::memory_order_relaxed);
+      if (track_statistics)
+      {
+        fast_micro_hits_since_clear_.fetch_add(1, std::memory_order_relaxed);
+        fast_micro_hits_since_clear_us_.fetch_add(
+            std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - start_time).count(),
+            std::memory_order_relaxed);
+      }
       return distance;
     }
     else
@@ -1065,40 +1099,43 @@ double Costmap3DQuery::calculateDistance(const geometry_msgs::Pose& pose,
     tls_last_cache_entries_[query_region][query_obstacles].clear();
   }
 
-  if (micro_hit)
+  if (track_statistics)
   {
-    slow_micro_hits_since_clear_.fetch_add(1, std::memory_order_relaxed);
-    slow_micro_hits_since_clear_us_.fetch_add(
-        std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - start_time).count(),
-        std::memory_order_relaxed);
-    hit_fcl_bv_distance_calculations_.fetch_add(result.bv_distance_calculations);
-    hit_fcl_primative_distance_calculations_.fetch_add(result.primative_distance_calculations);
-  }
-  else if (milli_hit)
-  {
-    slow_milli_hits_since_clear_.fetch_add(1, std::memory_order_relaxed);
-    slow_milli_hits_since_clear_us_.fetch_add(
-        std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - start_time).count(),
-        std::memory_order_relaxed);
-    hit_fcl_bv_distance_calculations_.fetch_add(result.bv_distance_calculations);
-    hit_fcl_primative_distance_calculations_.fetch_add(result.primative_distance_calculations);
-  }
-  else if (cache_hit)
-  {
-    hits_since_clear_.fetch_add(1, std::memory_order_relaxed);
-    hits_since_clear_us_.fetch_add(
-        std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - start_time).count(),
-        std::memory_order_relaxed);
-    hit_fcl_bv_distance_calculations_.fetch_add(result.bv_distance_calculations);
-    hit_fcl_primative_distance_calculations_.fetch_add(result.primative_distance_calculations);
-  }
-  else
-  {
-    misses_since_clear_us_.fetch_add(
-        std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - start_time).count(),
-        std::memory_order_relaxed);
-    miss_fcl_bv_distance_calculations_.fetch_add(result.bv_distance_calculations);
-    miss_fcl_primative_distance_calculations_.fetch_add(result.primative_distance_calculations);
+    if (micro_hit)
+    {
+      slow_micro_hits_since_clear_.fetch_add(1, std::memory_order_relaxed);
+      slow_micro_hits_since_clear_us_.fetch_add(
+          std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - start_time).count(),
+          std::memory_order_relaxed);
+      hit_fcl_bv_distance_calculations_.fetch_add(result.bv_distance_calculations);
+      hit_fcl_primative_distance_calculations_.fetch_add(result.primative_distance_calculations);
+    }
+    else if (milli_hit)
+    {
+      slow_milli_hits_since_clear_.fetch_add(1, std::memory_order_relaxed);
+      slow_milli_hits_since_clear_us_.fetch_add(
+          std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - start_time).count(),
+          std::memory_order_relaxed);
+      hit_fcl_bv_distance_calculations_.fetch_add(result.bv_distance_calculations);
+      hit_fcl_primative_distance_calculations_.fetch_add(result.primative_distance_calculations);
+    }
+    else if (cache_hit)
+    {
+      hits_since_clear_.fetch_add(1, std::memory_order_relaxed);
+      hits_since_clear_us_.fetch_add(
+          std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - start_time).count(),
+          std::memory_order_relaxed);
+      hit_fcl_bv_distance_calculations_.fetch_add(result.bv_distance_calculations);
+      hit_fcl_primative_distance_calculations_.fetch_add(result.primative_distance_calculations);
+    }
+    else
+    {
+      misses_since_clear_us_.fetch_add(
+          std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - start_time).count(),
+          std::memory_order_relaxed);
+      miss_fcl_bv_distance_calculations_.fetch_add(result.bv_distance_calculations);
+      miss_fcl_primative_distance_calculations_.fetch_add(result.primative_distance_calculations);
+    }
   }
 
   return distance;

--- a/costmap_3d/src/costmap_3d_query.cpp
+++ b/costmap_3d/src/costmap_3d_query.cpp
@@ -126,10 +126,106 @@ Costmap3DQuery::~Costmap3DQuery()
 void Costmap3DQuery::init()
 {
   clearStatistics();
-  milli_cache_threshold_ = 2.5 / pose_milli_bins_per_meter_;
-  micro_cache_threshold_ = 2.5 / pose_micro_bins_per_meter_;
   robot_model_halfspaces_.reset(new std::vector<fcl::Halfspace<FCLFloat>>);
   last_octomap_resolution_ = 0.0;
+}
+
+void Costmap3DQuery::setCacheBinSize(
+      unsigned int pose_bins_per_meter,
+      unsigned int pose_bins_per_radian,
+      unsigned int pose_milli_bins_per_meter,
+      unsigned int pose_milli_bins_per_radian,
+      unsigned int pose_micro_bins_per_meter,
+      unsigned int pose_micro_bins_per_radian)
+{
+  upgrade_lock upgradeable_lock(upgrade_mutex_);
+  if (pose_bins_per_meter != pose_bins_per_meter_ ||
+      pose_bins_per_radian != pose_bins_per_radian_ ||
+      pose_milli_bins_per_meter != pose_milli_bins_per_meter_ ||
+      pose_milli_bins_per_radian != pose_milli_bins_per_radian_ ||
+      pose_micro_bins_per_meter != pose_micro_bins_per_meter_ ||
+      pose_micro_bins_per_radian != pose_micro_bins_per_radian_)
+  {
+    upgrade_to_unique_lock write_lock(upgradeable_lock);
+    // There is no need to invalidate the existing cache entries. If the bins
+    // per meter change, either some or all of the new calls will miss the
+    // existing cache entries. The existing entries are all still correct, so
+    // keeping them is fine. Also, if only the thresholds change all the cache
+    // entries will still work.
+    pose_bins_per_meter_ = pose_bins_per_meter;
+    pose_bins_per_radian_ = pose_bins_per_radian;
+    pose_milli_bins_per_meter_ = pose_milli_bins_per_meter;
+    pose_milli_bins_per_radian_ = pose_milli_bins_per_radian;
+    pose_micro_bins_per_meter_ = pose_micro_bins_per_meter;
+    pose_micro_bins_per_radian_ = pose_micro_bins_per_radian;
+    ROS_INFO_STREAM("Set cache bins per meter: " << pose_bins_per_meter_);
+    ROS_INFO_STREAM("Set cache bins per radian: " << pose_bins_per_radian_);
+    ROS_INFO_STREAM("Set milli-cache bins per meter: " << pose_milli_bins_per_meter_);
+    ROS_INFO_STREAM("Set milli-cache bins per radian: " << pose_milli_bins_per_radian_);
+    ROS_INFO_STREAM("Set micro-cache bins per meter: " << pose_micro_bins_per_meter_);
+    ROS_INFO_STREAM("Set micro-cache bins per radian: " << pose_micro_bins_per_radian_);
+    calculateCacheDistanceThresholds();
+  }
+}
+
+void Costmap3DQuery::setCacheThresholdParameters(
+    bool threshold_two_d_mode,
+    double threshold_factor)
+{
+  upgrade_lock upgradeable_lock(upgrade_mutex_);
+  if (threshold_two_d_mode != threshold_two_d_mode_ ||
+      threshold_factor != threshold_factor_)
+  {
+    upgrade_to_unique_lock write_lock(upgradeable_lock);
+    threshold_two_d_mode_ = threshold_two_d_mode;
+    threshold_factor_ = threshold_factor;
+    ROS_INFO_STREAM("Set threshold 2D mode: " << threshold_two_d_mode_ ? "true" : "false");
+    ROS_INFO_STREAM("Set threshold factor: " << threshold_factor_);
+    calculateCacheDistanceThresholds();
+  }
+}
+
+void Costmap3DQuery::calculateCacheDistanceThresholds()
+{
+  // The distance thresholds must be greater than the maximum translation error
+  // plus the maximum rotation error, otherwise the query may return
+  // no-collision when one is actually present. In a robot with full
+  // three-dimensional movement this would equate to the length of the diagonal
+  // of a bin plus the chord length corresponding to the size of a rotational
+  // bin given the maximum radius of the robot mesh. For two-dimensional
+  // movement of a robot on a plane aligned with the costmap, the threshold
+  // is lower at only the diagonal of the bin projected into the plane as
+  // a square and the chord length given the radius of the robot mesh projected
+  // into the plane (the robot footprint radius).
+  Eigen::Vector4f origin(0.0, 0.0, 0.0, 0.0), max_pt(0.0, 0.0, 0.0, 0.0);
+  double diagonal_factor;
+  if (threshold_two_d_mode_)
+  {
+    // Create a 2D version of the mesh cloud by truncating the Z value.
+    pcl::PointCloud<pcl::PointXYZ> mesh_points_2d(*robot_mesh_points_);
+    for (auto& point : mesh_points_2d)
+    {
+      point.z = 0.0;
+    }
+    pcl::getMaxDistance(mesh_points_2d, origin, max_pt);
+    diagonal_factor = std::sqrt(2.0);
+  }
+  else
+  {
+    pcl::getMaxDistance(*robot_mesh_points_, origin, max_pt);
+    diagonal_factor = std::sqrt(3.0);
+  }
+  const Eigen::Vector3f max_pt3 = max_pt.head<3>();
+  double mesh_radius = max_pt3.norm();
+  milli_cache_threshold_ = diagonal_factor / pose_milli_bins_per_meter_ +
+    2.0 * mesh_radius * std::sin(0.5 / pose_milli_bins_per_radian_);
+  micro_cache_threshold_ = diagonal_factor / pose_micro_bins_per_meter_ +
+    2.0 * mesh_radius * std::sin(0.5 / pose_micro_bins_per_radian_);
+  milli_cache_threshold_ *= threshold_factor_;
+  micro_cache_threshold_ *= threshold_factor_;
+  ROS_INFO_STREAM("Calculated mesh radius: " << mesh_radius << "m");
+  ROS_INFO_STREAM("Calculated milli-distance cache threshold: " << milli_cache_threshold_ << "m");
+  ROS_INFO_STREAM("Calculated micro-distance cache threshold: " << micro_cache_threshold_ << "m");
 }
 
 void Costmap3DQuery::updateCostmap(const Costmap3DConstPtr& costmap_3d)
@@ -469,6 +565,7 @@ void Costmap3DQuery::updateMeshResource(const std::string& mesh_resource, double
             robot_model_->vertices[tri[1]],
             robot_model_->vertices[tri[2]]));
   }
+  calculateCacheDistanceThresholds();
 }
 
 std::string Costmap3DQuery::getFileNameFromPackageURL(const std::string& url)

--- a/costmap_3d/src/costmap_3d_query.cpp
+++ b/costmap_3d/src/costmap_3d_query.cpp
@@ -814,7 +814,7 @@ double Costmap3DQuery::calculateDistance(const geometry_msgs::Pose& pose,
   assert(octree_to_query);
 
   // FCL does not correctly handle an empty octomap.
-  if (octree_to_query->size() == 0)
+  if (octree_to_query->size() == 0 || !octree_to_query->isNodeOccupied(octree_to_query->getRoot()))
   {
     empties_since_clear_.fetch_add(1, std::memory_order_relaxed);
     return std::numeric_limits<double>::max();


### PR DESCRIPTION
Fixes and misc improvements to the query object. This includes significantly improving hash performance, and cleaning up locking to the minimum amount of time as possible (to improve parallel query performance), and fixing a bug with the Cayley transform scale.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BadgerTechnologies/navigation/50)
<!-- Reviewable:end -->
