### PR TITLE
costmap_3d: fix unsubscribe deadlocks

### DIFF
--- a/costmap_3d/plugins/point_cloud_layer_3d.cpp
+++ b/costmap_3d/plugins/point_cloud_layer_3d.cpp
@@ -115,9 +115,9 @@ void PointCloudLayer3D::updateBounds(
 
 void PointCloudLayer3D::deactivate()
 {
+  unsubscribe();
   std::lock_guard<Layer3D> lock(*this);
   active_ = false;
-  unsubscribe();
   super::deactivate();
 }
 

--- a/costmap_3d/plugins/static_2d_layer_3d.cpp
+++ b/costmap_3d/plugins/static_2d_layer_3d.cpp
@@ -112,9 +112,9 @@ void Static2DLayer3D::updateBounds(
 
 void Static2DLayer3D::deactivate()
 {
+  unsubscribe();
   std::lock_guard<Layer3D> lock(*this);
   active_ = false;
-  unsubscribe();
   super::deactivate();
   if (costmap_)
   {
@@ -139,8 +139,8 @@ void Static2DLayer3D::reset()
   // On a reset, resubscribe to get a new copy of the static map.
   // This is not strictly necessary, but provides an interface to force a reset.
   // Resubscribing is also what the costmap_2d static layer does on reset.
-  std::lock_guard<Layer3D> lock(*this);
   unsubscribe();
+  std::lock_guard<Layer3D> lock(*this);
   if (costmap_)
   {
     // Ensure the next costmap update will not have any old information from


### PR DESCRIPTION
Calling `shutdown` on a subscription synchronizes on all outstanding callbacks from the subscriber. If those callbacks grab a lock, it is incorrect to call unsubscribe while holding said lock. It is safe to unsubscribe without holding the lock as the subscribers are thread-safe. After the unsubscribe completes, it is guaranteed that no callbacks are running (or will be scheduled) from the subscriber.

Move all places where unsubscribe was called outside of holding the locks that are acquired inside their respective callbacks. Otherwise, deadlocks ensue if using a multi-threaded spinner.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BadgerTechnologies/navigation/53)
<!-- Reviewable:end -->
